### PR TITLE
Merkstore

### DIFF
--- a/src/merkstore/merkstore.rs
+++ b/src/merkstore/merkstore.rs
@@ -7,13 +7,13 @@ type Map = BTreeMap<Vec<u8>, Option<Vec<u8>>>;
 
 pub struct MerkStore<'a> {
     merk: &'a mut Merk,
-    map: Map
+    map: Option<Map>
 }
 
 impl<'a> MerkStore<'a> {
     pub fn new(merk: &'a mut Merk) -> Self {
         MerkStore {
-            map: Default::default(),
+            map: Some(Default::default()),
             merk
         }
     }
@@ -21,7 +21,7 @@ impl<'a> MerkStore<'a> {
 
 impl<'a> Read for MerkStore<'a> {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        match self.map.get(key) {
+        match self.map.as_ref().unwrap().get(key) {
             Some(Some(value)) => Ok(Some(value.clone())),
             Some(None) => Ok(None),
             None => Ok(self.merk.get(key)?)
@@ -31,19 +31,21 @@ impl<'a> Read for MerkStore<'a> {
 
 impl<'a> Write for MerkStore<'a> {
     fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
-        self.map.insert(key, Some(value));
+        self.map.as_mut().unwrap().insert(key, Some(value));
         Ok(())
     }
     fn delete(&mut self, key:  &[u8]) -> Result<()> {
-        self.map.insert(key.to_vec(), None);
+        self.map.as_mut().unwrap().insert(key.to_vec(), None);
         Ok(())
     }
 }
 
 impl<'a> Flush for MerkStore<'a> {
-    fn flush(self) -> Result<()> {
+    fn flush(&mut self) -> Result<()> {
+        let map = self.map.take().unwrap();
+        self.map = Some(Map::new());
         let mut batch = Vec::new();
-        for (key, val) in self.map {
+        for (key, val) in map {
             match val {
                 Some(val) => batch.push((key, Op::Put(val))),
                 None => batch.push((key, Op::Delete))

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -44,7 +44,7 @@ impl<S: Read + Write + Sized> Store for S {
 pub trait Flush {
     // TODO: should this consume the store? or will we want it like this so we
     // can persist the same wrapper store and flush it multiple times?
-    fn flush(self) -> Result<()>;
+    fn flush(&mut self) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/src/store/write_cache.rs
+++ b/src/store/write_cache.rs
@@ -55,7 +55,7 @@ impl<'a, S: Store> Write for WriteCache<'a, S> {
 }
 
 impl<'a, S: Store> Flush for WriteCache<'a, S> {
-    fn flush(mut self) -> Result<()> {
+    fn flush(&mut self) -> Result<()> {
         for (key, value) in self.map.drain() {
             match value {
                 Some(value) => self.store.put(key, value)?,


### PR DESCRIPTION
Changed Store Flush trait parameter to take in &mut self instead of self. Changed rest of files that uses that trait (write_cash.rs, merkstore.rs) accordingly. 