### PR TITLE
Merkstore

### DIFF
--- a/src/merkstore/merkstore.rs
+++ b/src/merkstore/merkstore.rs
@@ -1,4 +1,4 @@
-use merk::{Merk, Op};
+use merk::{Merk, Op, Hash};
 use std::collections::BTreeMap;
 use crate::error::Result;
 use crate::store::*;
@@ -53,5 +53,11 @@ impl<'a> Flush for MerkStore<'a> {
         }
         self.merk.apply(batch.as_ref())?;
         Ok(())
+    }
+}
+
+impl<'a> RootHash for MerkStore<'a> {
+    fn root_hash(&self) -> [u8; 20] {
+        self.merk.root_hash()
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -41,6 +41,10 @@ impl<S: Read + Write + Sized> Store for S {
     }
 }
 
+pub trait RootHash {
+    fn root_hash(&self) -> [u8; 20];
+}
+
 pub trait Flush {
     // TODO: should this consume the store? or will we want it like this so we
     // can persist the same wrapper store and flush it multiple times?


### PR DESCRIPTION
RootHash trait returns root hash of tree. Implemented inside MerkStore to use merk method root_hash()