### PR TITLE
Derive entry one tuple edge case

### DIFF
--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -265,11 +265,34 @@ fn generate_unnamed_impl_block(
 }
 
 fn generate_unnamed_one_tuple_from_body(
-    key_field_index: &syn::Index,
-    value_field_indices: &Vec<syn::Index>,
+    key: Vec<(syn::Index, syn::Type)>,
+    values: Vec<(syn::Index, syn::Type)>,
 ) -> Vec<TokenStream2> {
-    let output = quote! {};
-    vec![output]
+    let mut field_key_status = BTreeMap::new();
+
+    field_key_status.insert(key.get(0).unwrap().0.index, true);
+
+    for value in values {
+        let val_index = value.0;
+        field_key_status.insert(val_index.index, false);
+    }
+
+    let mut num_vals = 0;
+
+    let output: Vec<TokenStream2> = field_key_status
+        .iter()
+        .map(|(_, is_key)| match is_key {
+            true => {
+                quote! { item.0}
+            }
+            false => {
+                let j = syn::Index::from(num_vals);
+                num_vals += 1;
+                quote! { item.1.#j}
+            }
+        })
+        .collect();
+    output
 }
 
 fn generate_unnamed_one_tuple_impl_block(

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -153,13 +153,37 @@ fn generate_named_one_tuple_from_body(
 
 fn generate_named_one_tuple_impl_block(
     ident: syn::Ident,
-    key_field_names: Vec<syn::Ident>,
-    key_field_types: Vec<syn::Type>,
+    key_field_name: &syn::Ident,
+    key_field_type: &syn::Type,
     value_field_names: Vec<syn::Ident>,
     value_field_types: Vec<syn::Type>,
     from_body: Vec<TokenStream2>,
 ) -> TokenStream {
-    let output = quote! {};
+    let output = quote! {
+        impl ::orga::collections::Entry for #ident {
+            type Key = #key_field_type;
+
+            type Value = (
+                #(#value_field_types,)*
+            );
+
+            fn into_entry(self) -> (Self::Key, Self::Value) {
+                (
+                    self.#key_field_name,
+                    (#(
+                        self.#value_field_names,
+                    )*),
+                )
+            }
+
+            fn from_entry(item: (Self::Key, Self::Value)) -> Self {
+                Self {
+                    #(#from_body)*
+                }
+            }
+        }
+    };
+
     output.into()
 }
 

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -265,16 +265,15 @@ fn generate_unnamed_impl_block(
 }
 
 fn generate_unnamed_one_tuple_from_body(
-    key: Vec<(syn::Index, syn::Type)>,
-    values: Vec<(syn::Index, syn::Type)>,
+    key: &syn::Index,
+    values: &Vec<syn::Index>,
 ) -> Vec<TokenStream2> {
     let mut field_key_status = BTreeMap::new();
 
-    field_key_status.insert(key.get(0).unwrap().0.index, true);
+    field_key_status.insert(key.index, true);
 
     for value in values {
-        let val_index = value.0;
-        field_key_status.insert(val_index.index, false);
+        field_key_status.insert(value.index, false);
     }
 
     let mut num_vals = 0;
@@ -299,7 +298,7 @@ fn generate_unnamed_one_tuple_impl_block(
     ident: syn::Ident,
     key_field_index: &syn::Index,
     key_field_type: &syn::Type,
-    value_field_indices: Vec<syn::Index>,
+    value_field_indices: &Vec<syn::Index>,
     value_field_types: Vec<syn::Type>,
     from_body: Vec<TokenStream2>,
 ) -> TokenStream {
@@ -345,12 +344,13 @@ fn derive_unnamed_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStrea
             let key_field_index = key_field_indices.get(0).unwrap();
             let key_field_type = key_field_types.get(0).unwrap();
 
-            let from_body = generate_unnamed_one_tuple_from_body(keys, values);
+            let from_body =
+                generate_unnamed_one_tuple_from_body(key_field_index, &value_field_indices);
             generate_unnamed_one_tuple_impl_block(
                 ident,
                 key_field_index,
                 key_field_type,
-                value_field_indices,
+                &value_field_indices,
                 value_field_types,
                 from_body,
             )

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -191,18 +191,16 @@ fn derive_named_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStream 
 }
 
 fn generate_unnamed_struct_from_body(
-    keys: Vec<(syn::Index, syn::Type)>,
-    values: Vec<(syn::Index, syn::Type)>,
+    keys: &Vec<syn::Index>,
+    values: &Vec<syn::Index>,
 ) -> Vec<TokenStream2> {
     let mut field_key_status = BTreeMap::new();
 
     for key in keys {
-        let key_index = key.0;
-        field_key_status.insert(key_index.index, true);
+        field_key_status.insert(key.index, true);
     }
     for value in values {
-        let val_index = value.0;
-        field_key_status.insert(val_index.index, false);
+        field_key_status.insert(value.index, false);
     }
 
     let mut num_keys = 0;
@@ -228,9 +226,9 @@ fn generate_unnamed_struct_from_body(
 
 fn generate_unnamed_impl_block(
     ident: syn::Ident,
-    key_field_indices: Vec<syn::Index>,
+    key_field_indices: &Vec<syn::Index>,
     key_field_types: Vec<syn::Type>,
-    value_field_indices: Vec<syn::Index>,
+    value_field_indices: &Vec<syn::Index>,
     value_field_types: Vec<syn::Type>,
     from_body: Vec<TokenStream2>,
 ) -> TokenStream {
@@ -356,12 +354,13 @@ fn derive_unnamed_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStrea
             )
         }
         _ => {
-            let from_body = generate_unnamed_struct_from_body(keys, values);
+            let from_body =
+                generate_unnamed_struct_from_body(&key_field_indices, &value_field_indices);
             generate_unnamed_impl_block(
                 ident,
-                key_field_indices,
+                &key_field_indices,
                 key_field_types,
-                value_field_indices,
+                &value_field_indices,
                 value_field_types,
                 from_body,
             )

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -200,12 +200,14 @@ fn derive_named_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStream 
     match key_field_types.len() {
         0 => panic!("Entry derivation requires at least one key field to be specified."),
         1 => {
-            let from_body =
-                generate_named_one_tuple_from_body(&key_field_names, &value_field_names);
+            let key_field_name = key_field_names.get(0).unwrap();
+            let key_field_type = key_field_types.get(0).unwrap();
+
+            let from_body = generate_named_one_tuple_from_body(&key_field_name, &value_field_names);
             generate_named_one_tuple_impl_block(
                 ident,
-                key_field_names,
-                key_field_types,
+                key_field_name,
+                key_field_type,
                 value_field_names,
                 value_field_types,
                 from_body,

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -345,8 +345,7 @@ fn derive_unnamed_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStrea
             let key_field_index = key_field_indices.get(0).unwrap();
             let key_field_type = key_field_types.get(0).unwrap();
 
-            let from_body =
-                generate_unnamed_one_tuple_from_body(key_field_index, &value_field_indices);
+            let from_body = generate_unnamed_one_tuple_from_body(keys, values);
             generate_unnamed_one_tuple_impl_block(
                 ident,
                 key_field_index,

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -303,7 +303,29 @@ fn generate_unnamed_one_tuple_impl_block(
     value_field_types: Vec<syn::Type>,
     from_body: Vec<TokenStream2>,
 ) -> TokenStream {
-    let output = quote! {};
+    let output = quote! {
+        impl ::orga::collections::Entry for #ident {
+            type Key = #key_field_type;
+
+            type Value = (
+                #(#value_field_types,)*
+            );
+
+            fn into_entry(self) -> (Self::Key, Self::Value) {
+                (
+                    self.#key_field_index,
+                    (#(
+                        self.#value_field_indices,
+                    )*),
+                )
+            }
+
+            fn from_entry(item: (Self::Key, Self::Value)) -> Self {
+                Self(#(#from_body,)*)
+            }
+        }
+    };
+
     output.into()
 }
 

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -96,43 +96,6 @@ fn generate_named_impl_block(
     output.into()
 }
 
-fn generate_unnamed_struct_body(
-    keys: Vec<(syn::Index, syn::Type)>,
-    values: Vec<(syn::Index, syn::Type)>,
-) -> std::vec::IntoIter<TokenStream2> {
-    let mut field_key_status = BTreeMap::new();
-
-    for key in keys {
-        let key_index = key.0;
-        field_key_status.insert(key_index.index, true);
-    }
-    for value in values {
-        let val_index = value.0;
-        field_key_status.insert(val_index.index, false);
-    }
-
-    let mut num_keys = 0;
-    let mut num_vals = 0;
-
-    let output: Vec<TokenStream2> = field_key_status
-        .iter()
-        .map(|(_, is_key)| match is_key {
-            true => {
-                let j = syn::Index::from(num_keys);
-                num_keys += 1;
-                quote! { item.0.#j}
-            }
-            false => {
-                let j = syn::Index::from(num_vals);
-                num_vals += 1;
-                quote! { item.1.#j}
-            }
-        })
-        .collect();
-
-    output.into_iter()
-}
-
 fn generate_named_one_tuple_from_body(
     key_field_name: &syn::Ident,
     value_field_names: &Vec<syn::Ident>,
@@ -225,6 +188,43 @@ fn derive_named_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStream 
             )
         }
     }
+}
+
+fn generate_unnamed_struct_body(
+    keys: Vec<(syn::Index, syn::Type)>,
+    values: Vec<(syn::Index, syn::Type)>,
+) -> std::vec::IntoIter<TokenStream2> {
+    let mut field_key_status = BTreeMap::new();
+
+    for key in keys {
+        let key_index = key.0;
+        field_key_status.insert(key_index.index, true);
+    }
+    for value in values {
+        let val_index = value.0;
+        field_key_status.insert(val_index.index, false);
+    }
+
+    let mut num_keys = 0;
+    let mut num_vals = 0;
+
+    let output: Vec<TokenStream2> = field_key_status
+        .iter()
+        .map(|(_, is_key)| match is_key {
+            true => {
+                let j = syn::Index::from(num_keys);
+                num_keys += 1;
+                quote! { item.0.#j}
+            }
+            false => {
+                let j = syn::Index::from(num_vals);
+                num_vals += 1;
+                quote! { item.1.#j}
+            }
+        })
+        .collect();
+
+    output.into_iter()
 }
 
 fn derive_unnamed_struct(data: syn::DataStruct, ident: syn::Ident) -> TokenStream {

--- a/macros/src/entry.rs
+++ b/macros/src/entry.rs
@@ -134,11 +134,21 @@ fn generate_unnamed_struct_body(
 }
 
 fn generate_named_one_tuple_from_body(
-    key_field_names: &Vec<syn::Ident>,
+    key_field_name: &syn::Ident,
     value_field_names: &Vec<syn::Ident>,
 ) -> Vec<TokenStream2> {
-    let output = quote! {};
-    vec![output.into()]
+    let key_quote = quote! { #key_field_name: item.0, };
+    let mut value_quote: Vec<TokenStream2> = value_field_names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let index = syn::Index::from(i);
+            quote! { #name: item.1.#index,}
+        })
+        .collect();
+    value_quote.push(key_quote);
+
+    value_quote
 }
 
 fn generate_named_one_tuple_impl_block(

--- a/src/collections/entry_map.rs
+++ b/src/collections/entry_map.rs
@@ -157,26 +157,11 @@ mod test {
     #[allow(dead_code)]
     type EntryMap<T> = OrgaEntryMap<T, MapStore>;
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Entry, Debug, Eq, PartialEq)]
     pub struct MapEntry {
+        #[key]
         key: u32,
         value: u32,
-    }
-
-    impl Entry for MapEntry {
-        type Key = u32;
-        type Value = u32;
-
-        fn into_entry(self) -> (Self::Key, Self::Value) {
-            (self.key, self.value)
-        }
-
-        fn from_entry(entry: (Self::Key, Self::Value)) -> Self {
-            MapEntry {
-                key: entry.0,
-                value: entry.1,
-            }
-        }
     }
 
     #[test]

--- a/src/collections/entry_map.rs
+++ b/src/collections/entry_map.rs
@@ -164,6 +164,9 @@ mod test {
         value: u32,
     }
 
+    #[derive(Entry, Debug, Eq, PartialEq)]
+    pub struct TupleMapEntry(#[key] u32, u32);
+
     #[test]
     fn insert() {
         let store = Store::new(MapStore::new());
@@ -358,5 +361,55 @@ mod test {
         assert!(entry_map
             .contains_entry_key(MapEntry { key: 12, value: 13 })
             .unwrap());
+    }
+
+    #[test]
+    fn iter_tuple_struct() {
+        let store = Store::new(MapStore::new());
+        let mut entry_map: EntryMap<TupleMapEntry> = EntryMap::create(store.clone(), ()).unwrap();
+
+        entry_map.insert(TupleMapEntry(12, 24)).unwrap();
+        entry_map.insert(TupleMapEntry(13, 26)).unwrap();
+        entry_map.insert(TupleMapEntry(14, 28)).unwrap();
+
+        let actual: Vec<TupleMapEntry> = vec![
+            TupleMapEntry(12, 24),
+            TupleMapEntry(13, 26),
+            TupleMapEntry(14, 28),
+        ];
+
+        let result: bool = entry_map
+            .iter()
+            .unwrap()
+            .zip(actual.iter())
+            .map(|(actual, expected)| *actual.unwrap() == *expected)
+            .fold(true, |accumulator, item| item & accumulator);
+
+        assert!(result);
+    }
+
+    #[test]
+    fn range_full_tuple_struct() {
+        let store = Store::new(MapStore::new());
+        let mut entry_map: EntryMap<TupleMapEntry> = EntryMap::create(store.clone(), ()).unwrap();
+
+        entry_map.insert(TupleMapEntry(12, 24)).unwrap();
+        entry_map.insert(TupleMapEntry(13, 26)).unwrap();
+        entry_map.insert(TupleMapEntry(14, 28)).unwrap();
+
+        let expected_entries: Vec<TupleMapEntry> = vec![
+            TupleMapEntry(12, 24),
+            TupleMapEntry(13, 26),
+            TupleMapEntry(14, 28),
+        ];
+
+        let result: bool = entry_map
+            .range(..)
+            .unwrap()
+            .zip(expected_entries.iter())
+            .map(|(actual, expected)| *actual.unwrap() == *expected)
+            .fold(true, |accumulator, item| item & accumulator);
+
+        assert!(result);
     }
 }


### PR DESCRIPTION
Handles cases where only one #[key] is supplied on structs that derive Entry. Instead of wrapping this single type in a tuple, the tuple wrapping is omitted. Resolves #64.