### PR TITLE
Support generic structs in State derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,6 @@ required-features = ["merk", "abci"]
 name = "contexts"
 required-features = ["merk", "abci"]
 
-
+[[example]]
+name = "simple-coin"
+required-features = ["merk", "abci"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-lite = "1.12.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-tokio = "1.11.0"
+tokio = { version = "1.11.0", features = ["rt", "macros"] }
 
 [package.metadata.docs.rs]
 features = ["abci", "merk"]

--- a/macros/src/state.rs
+++ b/macros/src/state.rs
@@ -3,6 +3,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use std::str::FromStr;
 use syn::*;
+use super::utils::gen_param_input;
 
 pub fn derive(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as DeriveInput);
@@ -23,6 +24,10 @@ pub fn derive(item: TokenStream) -> TokenStream {
         || (0..field_names().count()).map(|i| TokenStream2::from_str(&i.to_string()).unwrap());
 
     let name = &item.ident;
+    let generics = &item.generics;
+    let where_clause = &generics.where_clause;
+    let generic_params = gen_param_input(&generics, true);
+
     let field_types_encoding = field_types();
     let seq_substore = seq();
     let seq_data = seq();
@@ -82,7 +87,9 @@ pub fn derive(item: TokenStream) -> TokenStream {
     };
 
     let output = quote! {
-        impl ::orga::state::State for #name {
+        impl#generics ::orga::state::State for #name#generic_params
+        #where_clause
+        {
             type Encoding = (
                 #(
                     <#field_types_encoding as ::orga::state::State>::Encoding,
@@ -101,8 +108,10 @@ pub fn derive(item: TokenStream) -> TokenStream {
             }
         }
 
-        impl From<#name> for <#name as ::orga::state::State>::Encoding {
-            fn from(value: #name) -> Self {
+        impl#generics From<#name#generic_params> for <#name#generic_params as ::orga::state::State>::Encoding
+        #where_clause
+        {
+            fn from(value: #name#generic_params) -> Self {
                 (#from_body)
             }
         }

--- a/macros/src/state.rs
+++ b/macros/src/state.rs
@@ -1,9 +1,9 @@
+use super::utils::gen_param_input;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use std::str::FromStr;
 use syn::*;
-use super::utils::gen_param_input;
 
 pub fn derive(item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as DeriveInput);

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -1,5 +1,7 @@
 use std::collections::HashSet;
 use syn::*;
+use quote::quote;
+use proc_macro2::TokenStream;
 
 pub fn parse_parent() -> File {
     let path = proc_macro::Span::call_site().source_file().path();
@@ -126,4 +128,30 @@ pub fn relevant_methods(
         .into_iter()
         .flat_map(get_methods)
         .collect()
+}
+
+
+pub fn gen_param_input(generics: &Generics, bracketed: bool) -> TokenStream {
+    let gen_params = generics.params.iter().map(|p| match p {
+        GenericParam::Type(p) => {
+            let ident = &p.ident;
+            quote!(#ident)
+        }
+        GenericParam::Lifetime(p) => {
+            let ident = &p.lifetime.ident;
+            quote!(#ident)
+        }
+        GenericParam::Const(p) => {
+            let ident = &p.ident;
+            quote!(#ident)
+        }
+    });
+
+    if gen_params.len() == 0 {
+        quote!()
+    } else if bracketed {
+        quote!(<#(#gen_params),*>)
+    } else {
+        quote!(#(#gen_params),*)
+    }
 }

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -1,7 +1,7 @@
+use proc_macro2::TokenStream;
+use quote::quote;
 use std::collections::HashSet;
 use syn::*;
-use quote::quote;
-use proc_macro2::TokenStream;
 
 pub fn parse_parent() -> File {
     let path = proc_macro::Span::call_site().source_file().path();
@@ -129,7 +129,6 @@ pub fn relevant_methods(
         .flat_map(get_methods)
         .collect()
 }
-
 
 pub fn gen_param_input(generics: &Generics, bracketed: bool) -> TokenStream {
     let gen_params = generics.params.iter().map(|p| match p {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -156,6 +156,7 @@ mod tests {
 
     #[ignore]
     #[tokio::test]
+    #[cfg(feature = "abci")]
     async fn rpc_client() {
         use crate::abci::TendermintClient;
         let mut client = TendermintClient::<Foo>::new("http://localhost:26657").unwrap();

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -7,7 +7,9 @@ use orga::state::State;
 use orga::store::{MapStore, Shared, Store};
 
 #[derive(Encode, Decode, PartialEq, Debug)]
-struct Foo<T> {
+struct Foo<T>
+    where T: Default,
+{
     a: u8,
     b: Option<T>,
 }
@@ -54,6 +56,32 @@ fn struct_state() {
     let data = state.flush().unwrap();
     let bytes = data.encode().unwrap();
     assert_eq!(bytes, vec![0, 0, 0, 123, 0, 0, 0, 5, 0, 0, 0, 6]);
+}
+
+#[derive(State, PartialEq, Debug)]
+struct GenericStruct<T: State>
+where
+    T: Default,
+{
+    a: u8,
+    b: T,
+}
+
+#[test]
+fn generic_struct_state() {
+    let mapstore = Shared::new(MapStore::new());
+    let store = Store::new(mapstore.into());
+
+    let mut state = GenericStruct::<u64>::create(store, Default::default()).unwrap();
+
+    assert_eq!(state.a, 0);
+    assert_eq!(state.b, 0);
+
+    state.a = 123;
+    state.b = 5;
+
+    let data = state.flush().unwrap();
+    assert_eq!(data, (123, 5));
 }
 
 #[derive(Entry, Debug, PartialEq)]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -8,7 +8,8 @@ use orga::store::{MapStore, Shared, Store};
 
 #[derive(Encode, Decode, PartialEq, Debug)]
 struct Foo<T>
-    where T: Default,
+where
+    T: Default,
 {
     a: u8,
     b: Option<T>,


### PR DESCRIPTION
Closes #32

Now this should work:

```rust
#[derive(State)]
struct Foo<T: State> {
    inner: T,
}
```

There will probably be a bunch of hand-written State implementations across the codebase that can be removed in favor of deriving after this gets merged.