### PR TITLE
Fail when writing key lengths >= 256 bytes to Store

### DIFF
--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1,5 +1,5 @@
 use super::{Read, Shared, Write, KV};
-use crate::Result;
+use crate::{Result, Error};
 
 // TODO: figure out how to let users set DefaultBackingStore, similar to setting
 // the global allocator in the standard library
@@ -84,7 +84,7 @@ impl<S: Write> Write for Store<S> {
         // if we instead check this statically using known encoding lengths via
         // ed.
         if key.len() + self.prefix.len() >= 256 {
-            failure::bail!("Store keys must be < 256 bytes");
+            return Err(Error::Store("Store keys must be < 256 bytes".into()));
         }
 
         let prefixed = concat(self.prefix.as_slice(), key.as_slice());

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -1,5 +1,5 @@
 use super::{Read, Shared, Write, KV};
-use crate::{Result, Error};
+use crate::{Error, Result};
 
 // TODO: figure out how to let users set DefaultBackingStore, similar to setting
 // the global allocator in the standard library

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -77,6 +77,16 @@ impl<S: Read> Read for Store<S> {
 impl<S: Write> Write for Store<S> {
     #[inline]
     fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        // merk has a hard limit of 256 bytes for keys, but it does not create
+        // an error until comitting. we assert the key length here so that
+        // writes will fail early rather than making the entire block fail. this
+        // assertion can be removed if the merk key length limit is removed, or
+        // if we instead check this statically using known encoding lengths via
+        // ed.
+        if key.len() + self.prefix.len() >= 256 {
+            failure::bail!("Store keys must be < 256 bytes");
+        }
+
         let prefixed = concat(self.prefix.as_slice(), key.as_slice());
         self.store.put(prefixed, value)
     }


### PR DESCRIPTION
This is an easy safety fix to prevent a case where a key >= 256 bytes written to the store will cause the entire block to fail when writing to merk.

Will wait to merge this after #79 (will require changing the returned error) in the interest of not keeping that PR open forever.

Closes #61 

In the future, we can do a better form of checking at compile-time once ed has some sort of const generic length encoding length fields.