### PR TITLE
Tendermint config

### DIFF
--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -12,6 +12,7 @@ use home::home_dir;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::path::PathBuf;
+use std::process::Stdio;
 use tendermint_proto::abci::*;
 
 pub struct Node<A> {
@@ -23,6 +24,8 @@ pub struct Node<A> {
     abci_port: u16,
     genesis_bytes: Option<Vec<u8>>,
     p2p_persistent_peers: Option<Vec<String>>,
+    stdout: Stdio,
+    stderr: Stdio,
 }
 
 impl<A: App> Node<A>
@@ -52,6 +55,8 @@ where
             abci_port: 26658,
             genesis_bytes: None,
             p2p_persistent_peers: None,
+            stdout: Stdio::null(),
+            stderr: Stdio::null(),
         }
     }
 
@@ -60,11 +65,14 @@ where
         let tm_home = self.tm_home.clone();
         let p2p_port = self.p2p_port;
         let rpc_port = self.rpc_port;
+        let stdout = self.stdout;
+        let stderr = self.stderr;
         let maybe_genesis_bytes = self.genesis_bytes;
         let maybe_peers = self.p2p_persistent_peers;
         std::thread::spawn(move || {
             let mut tm_process = Tendermint::new(&tm_home)
-                .stdout(std::process::Stdio::null())
+                .stdout(stdout)
+                .stderr(stderr)
                 .p2p_laddr(format!("tcp://0.0.0.0:{}", p2p_port).as_str())
                 .rpc_laddr(format!("tcp://0.0.0.0:{}", rpc_port).as_str()); // Note: public by default
 
@@ -126,6 +134,18 @@ where
     pub fn peers<T: Borrow<str>>(mut self, peers: &[T]) -> Self {
         let peers = peers.iter().map(|p| p.borrow().to_string()).collect();
         self.p2p_persistent_peers.replace(peers);
+
+        self
+    }
+
+    pub fn stdout<T: Into<Stdio>>(mut self, stdout: T) -> Self {
+        self.stdout = stdout.into();
+
+        self
+    }
+
+    pub fn stderr<T: Into<Stdio>>(mut self, stderr: T) -> Self {
+        self.stderr = stderr.into();
 
         self
     }

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -11,7 +11,7 @@ use crate::Result;
 use home::home_dir;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tendermint_proto::abci::*;
 
 pub struct Node<A> {
@@ -21,7 +21,7 @@ pub struct Node<A> {
     p2p_port: u16,
     rpc_port: u16,
     abci_port: u16,
-    genesis_path: Option<PathBuf>,
+    genesis_bytes: Option<Vec<u8>>,
     p2p_persistent_peers: Option<Vec<String>>,
 }
 
@@ -50,7 +50,7 @@ where
             p2p_port: 26656,
             rpc_port: 26657,
             abci_port: 26658,
-            genesis_path: None,
+            genesis_bytes: None,
             p2p_persistent_peers: None,
         }
     }
@@ -60,7 +60,7 @@ where
         let tm_home = self.tm_home.clone();
         let p2p_port = self.p2p_port;
         let rpc_port = self.rpc_port;
-        let maybe_genesis_path = self.genesis_path;
+        let maybe_genesis_bytes = self.genesis_bytes;
         let maybe_peers = self.p2p_persistent_peers;
         std::thread::spawn(move || {
             let mut tm_process = Tendermint::new(&tm_home)
@@ -68,8 +68,8 @@ where
                 .p2p_laddr(format!("tcp://0.0.0.0:{}", p2p_port).as_str())
                 .rpc_laddr(format!("tcp://0.0.0.0:{}", rpc_port).as_str()); // Note: public by default
 
-            if let Some(genesis_path) = maybe_genesis_path {
-                tm_process = tm_process.with_genesis(genesis_path);
+            if let Some(genesis_bytes) = maybe_genesis_bytes {
+                tm_process = tm_process.with_genesis(genesis_bytes);
             }
 
             if let Some(peers) = maybe_peers {
@@ -117,8 +117,8 @@ where
         self
     }
 
-    pub fn with_genesis<P: AsRef<Path>>(mut self, genesis_path: P) -> Self {
-        self.genesis_path.replace(genesis_path.as_ref().into());
+    pub fn with_genesis<const N: usize>(mut self, genesis_bytes: &'static [u8; N]) -> Self {
+        self.genesis_bytes.replace(genesis_bytes.to_vec());
 
         self
     }

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use super::{ABCIStateMachine, ABCIStore, App, Application, WrappedMerk};
 use crate::call::Call;
 use crate::contexts::{ABCICall, ABCIProvider};
@@ -10,9 +8,12 @@ use crate::state::State;
 use crate::store::{Read, Shared, Store, Write};
 use crate::tendermint::Tendermint;
 use crate::Result;
+use home::home_dir;
 use std::borrow::Borrow;
+use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use tendermint_proto::abci::*;
+
 pub struct Node<A> {
     _app: PhantomData<A>,
     tm_home: PathBuf,
@@ -28,8 +29,10 @@ impl<A: App> Node<A>
 where
     <A as State>::Encoding: Default,
 {
-    pub fn new<P: AsRef<Path>>(home: P) -> Self {
-        let home: PathBuf = home.as_ref().into();
+    pub fn new(home: &str) -> Self {
+        let home: PathBuf = home_dir()
+            .expect("Could not resolve user home directory")
+            .join(format!(".{}", home).as_str());
         let merk_home = home.join("merk");
         let tm_home = home.join("tendermint");
         if !home.exists() {

--- a/src/tendermint/mod.rs
+++ b/src/tendermint/mod.rs
@@ -30,6 +30,8 @@ static TENDERMINT_ZIP_HASH: [u8; 32] =
 static TENDERMINT_ZIP_HASH: [u8; 32] =
     hex!("01a076d3297a5381587a77621b7f45dca7acb7fc21ce2e29ca327ccdaee41757");
 
+const TENDERMINT_BINARY_NAME: &str = "tendermint-v0.34.11";
+
 fn verify_hash(tendermint_bytes: &[u8]) {
     let mut hasher = Sha256::new();
     hasher.update(tendermint_bytes);
@@ -108,10 +110,11 @@ impl Tendermint {
     pub fn new<T: Into<PathBuf> + Clone>(home_path: T) -> Tendermint {
         let path: PathBuf = home_path.clone().into();
         if !path.exists() {
-            fs::create_dir(path).expect("Failed to create Tendermint home directory");
+            fs::create_dir(path.clone()).expect("Failed to create Tendermint home directory");
         }
+        let tm_bin_path = path.join(TENDERMINT_BINARY_NAME);
         let tendermint = Tendermint {
-            process: ProcessHandler::new("tendermint"),
+            process: ProcessHandler::new(tm_bin_path.to_str().unwrap()),
             home: home_path.clone().into(),
             genesis_path: None,
             config_contents: None,
@@ -120,7 +123,7 @@ impl Tendermint {
     }
 
     fn install(&self) {
-        let tendermint_path = self.home.join("tendermint-v0.34.11");
+        let tendermint_path = self.home.join(TENDERMINT_BINARY_NAME);
 
         if tendermint_path.is_executable() {
             info!("Tendermint already installed");
@@ -569,7 +572,7 @@ mod tests {
         let expected: HashSet<String> = HashSet::from([
             "config".to_string(),
             "data".to_string(),
-            "tendermint-v0.34.11".to_string(),
+            TENDERMINT_BINARY_NAME.to_string(),
         ]);
 
         assert_eq!(file_set, expected);


### PR DESCRIPTION
This PR:

- Exposes Tendermint stdout / stderr configuration
- Changes the way we specify a genesis in `Node` (previously took a path to the genesis, now expects bytes eg. via `include_bytes!()`)
- Puts app data in the user's home directory instead of cwd by default
- Uses a locally-installed Tendermint binary instead of whatever's in the user's path