### PR TITLE
Swap MapEntry::or_insert() for Map::insert() in Deque push methods

### DIFF
--- a/src/abci/mod.rs
+++ b/src/abci/mod.rs
@@ -240,7 +240,7 @@ impl<A: Application> ABCIStateMachine<A> {
                         .parse()
                         .expect("Invalid STOP_HEIGHT value");
                     assert!(
-                        !(self.height >= stop_height),
+                        self.height < stop_height,
                         "Reached stop height ({})",
                         stop_height
                     );

--- a/src/collections/deque.rs
+++ b/src/collections/deque.rs
@@ -112,8 +112,7 @@ impl<T: State<S>, S: Write> Deque<T, S> {
     pub fn push_back(&mut self, value: T::Encoding) -> Result<()> {
         let index = self.meta.tail;
         self.meta.tail += 1;
-        // TODO: use insert
-        self.map.entry(index)?.or_insert(value)?;
+        self.map.insert(index, value)?;
         Ok(())
     }
 
@@ -121,8 +120,7 @@ impl<T: State<S>, S: Write> Deque<T, S> {
     pub fn push_front(&mut self, value: T::Encoding) -> Result<()> {
         self.meta.head -= 1;
         let index = self.meta.head;
-        // TODO: use insert
-        self.map.entry(index)?.or_insert(value)?;
+        self.map.insert(index, value)?;
         Ok(())
     }
 

--- a/src/collections/deque.rs
+++ b/src/collections/deque.rs
@@ -16,7 +16,7 @@ pub struct Deque<T, S = DefaultBackingStore> {
     map: Map<u64, T, S>,
 }
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Clone)]
 pub struct Meta {
     head: u64,
     tail: u64,

--- a/src/plugins/signer.rs
+++ b/src/plugins/signer.rs
@@ -40,7 +40,7 @@ impl SignerCall {
         match (self.pubkey, self.signature) {
             (Some(pubkey_bytes), Some(signature)) => {
                 let pubkey = PublicKey::from_bytes(&pubkey_bytes)?;
-                let signature = Signature::new(signature);
+                let signature = Signature::from_bytes(&signature);
                 pubkey.verify_strict(&self.call_bytes, &signature)?;
 
                 Ok(Some(pubkey_bytes.into()))

--- a/src/plugins/signer.rs
+++ b/src/plugins/signer.rs
@@ -40,7 +40,7 @@ impl SignerCall {
         match (self.pubkey, self.signature) {
             (Some(pubkey_bytes), Some(signature)) => {
                 let pubkey = PublicKey::from_bytes(&pubkey_bytes)?;
-                let signature = Signature::from_bytes(&signature);
+                let signature = Signature::from_bytes(&signature)?;
                 pubkey.verify_strict(&self.call_bytes, &signature)?;
 
                 Ok(Some(pubkey_bytes.into()))


### PR DESCRIPTION
Resolves #107 in some capacity. Calling Deque's push_front or push_back calling MapEntry::or_insert() was causing panics for unwrap at None value @ line 836 of Map. This resolves the issue in the context of some usages, but there may be more paths that lead to this same issue. Blocked by #108.