### PR TITLE
State macro fix

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -129,7 +129,8 @@ where
         let mut vec: Vec<Result<T>> = Vec::with_capacity(N);
         self_vec
             .into_iter()
-            .for_each(|x| vec.push(T::create(store.clone(), x)));
+            .enumerate()
+            .for_each(|(i, x)| vec.push(T::create(store.sub(&[i as u8]), x)));
         let result: Result<Vec<T>> = vec.into_iter().collect();
         //since vec is directly created and populated from passed value, panic! will never be reached
         let result_array: [T; N] = result?.try_into().unwrap_or_else(|v: Vec<T>| {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -311,7 +311,7 @@ macro_rules! state_tuple_impl {
             where
                 S: Read,
             {
-                Ok(($($type::create(store.sub(&[$indices]), data.inner.$indices)?,)* $last_type::create(store.clone(), data.inner.$length)?))
+                Ok(($($type::create(store.sub(&[$indices]), data.inner.$indices)?,)* $last_type::create(store.sub(&[$indices]), data.inner.$length)?))
             }
 
             fn flush(self) -> Result<Self::Encoding> {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -311,7 +311,7 @@ macro_rules! state_tuple_impl {
             where
                 S: Read,
             {
-                Ok(($($type::create(store.sub(&[$indices]), data.inner.$indices)?,)* $last_type::create(store.sub(&[$indices]), data.inner.$length)?))
+                Ok(($($type::create(store.sub(&[$indices]), data.inner.$indices)?,)* $last_type::create(store.sub(&[$length]), data.inner.$length)?))
             }
 
             fn flush(self) -> Result<Self::Encoding> {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -269,7 +269,7 @@ where
     where
         S: Read,
     {
-        Ok((A::create(store, data.inner.0)?,))
+        Ok((A::create(store.sub(&[0]), data.inner.0)?,))
     }
 
     fn flush(self) -> Result<Self::Encoding> {
@@ -311,7 +311,7 @@ macro_rules! state_tuple_impl {
             where
                 S: Read,
             {
-                Ok(($($type::create(store.clone(), data.inner.$indices)?,)* $last_type::create(store.clone(), data.inner.$length)?))
+                Ok(($($type::create(store.sub(&[$indices]), data.inner.$indices)?,)* $last_type::create(store.clone(), data.inner.$length)?))
             }
 
             fn flush(self) -> Result<Self::Encoding> {


### PR DESCRIPTION
Adds key sub-storing to State implementations of arrays and tuples.

Example expanded output from tuple implementation:
```
#[derive(Encode, Decode)]
pub struct Encoded2Tuple<A, B, S>
where
    A: State<S>,
    B: State<S>,
{
    inner: (A::Encoding, B::Encoding),
}

impl<A, B, S> From<(A, B)> for Encoded2Tuple<A, B, S>
where
    A: State<S>,
    B: State<S>,
{
    fn from(value: (A, B)) -> Self {
        Encoded2Tuple {
            inner: (value.0.into(), value.1.into()),
        }
    }
}

impl<A, B, S> State<S> for (A, B)
where
    A: State<S>,
    B: State<S>,
    A::Encoding: ed::Terminated
{
    type Encoding = Encoded2Tuple<A, B, S>;
    
    fn create(store: Store<S>, data: Self::Encoding) -> Result<Self> {
        Ok((
            A::create(store.sub(&[0]), data.inner.0)?,
            B::create(store.sub(&[1]), data.inner.1)?,
        ))
    }
    
    fn flush(self) -> Result<Self::Encoding> {
        Ok(Encoded2Tuple {
            inner: (self.0.into(), self.1.into()),
        })
    }
}
```