### PR TITLE
[v2] Fix arm64 builds

### DIFF
--- a/src/tendermint/mod.rs
+++ b/src/tendermint/mod.rs
@@ -16,7 +16,7 @@ use toml_edit::{value, Document};
 static TENDERMINT_BINARY_URL: &str = "https://github.com/tendermint/tendermint/releases/download/v0.34.15/tendermint_0.34.15_darwin_amd64.tar.gz";
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 static TENDERMINT_BINARY_URL: &str = "https://github.com/tendermint/tendermint/releases/download/v0.34.15/tendermint_0.34.15_linux_amd64.tar.gz";
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 static TENDERMINT_BINARY_URL: &str = "https://github.com/tendermint/tendermint/releases/download/v0.34.15/tendermint_0.34.15_linux_arm64.tar.gz";
 
 #[cfg(target_os = "macos")]
@@ -25,7 +25,7 @@ static TENDERMINT_ZIP_HASH: [u8; 32] =
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 static TENDERMINT_ZIP_HASH: [u8; 32] =
     hex!("cf4bd4b5a57f49007d18b9287214daf364dbc11094dec8e4c1bc33f207c6c57c");
-#[cfg(all(target_os = "linux", target_arch = "arm"))]
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 static TENDERMINT_ZIP_HASH: [u8; 32] =
     hex!("6d4d771ae26c207f1a4f9f1399db2cbcac2e3c8afdf5d55d15bb984bbb986d2e");
 


### PR DESCRIPTION
Target for `arm64` should be `aarch64`. This is required in both latest and v2 due to migration imports in nomic.

Nomic arm64 build confirmed to work here https://github.com/agouin/nomic/tree/andrew/aarch64 (incorporates these changes in v2 and v3)

In order to fix nomic aarch64 builds:
- Merge this PR into `v2-legacy-main`, and merge this same patch into `develop` #153 and `v3-main` #155
- Update `v2` import in `develop` to latest `v2-legacy-main`
- Update `orga` `v2-legacy-main` import to latest in `nomic` branch `v2-legacy-main`
- Update nomic `nomicv2` import in `develop` branch to latest `v2-legacy-main` and `orga` import to latest `v3-main`