### PR TITLE
Historical queries

### DIFF
--- a/src/abci/mod.rs
+++ b/src/abci/mod.rs
@@ -602,5 +602,8 @@ impl<S: State> AbciQuery for S {
     }
 }
 
-pub trait App: BeginBlock + EndBlock + InitChain + State + Call + Query + Default {}
-impl<T: Default + BeginBlock + EndBlock + InitChain + State + Call + Query> App for T {}
+pub trait App:
+    BeginBlock + EndBlock + InitChain + State + Call + Query + Default + AbciQuery
+{
+}
+impl<T: Default + BeginBlock + EndBlock + InitChain + State + Call + Query + AbciQuery> App for T {}

--- a/src/abci/mod.rs
+++ b/src/abci/mod.rs
@@ -1,5 +1,3 @@
-use tendermint_proto::v0_34::types::Header;
-
 use crate::call::Call;
 use crate::query::Query;
 use crate::state::State;
@@ -27,6 +25,7 @@ mod server {
     use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
     use tendermint_proto::v0_34::abci::request::Value as Req;
     use tendermint_proto::v0_34::abci::response::Value as Res;
+    use tendermint_proto::v0_34::types::Header;
 
     /// Top-level struct for running an ABCI application. Maintains an ABCI server,
     /// mempool, and handles committing data to the store.

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -511,13 +511,9 @@ impl<A: App> InternalApp<ABCIPlugin<A>> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        abci::{BeginBlock, InitChain, Node},
-        client::{
-            wallet::{DerivedKey, Unsigned},
-            AppClient,
-        },
-        coins::{Accounts, Symbol},
-        collections::Map,
+        abci::{BeginBlock, Node},
+        client::{wallet::Unsigned, AppClient},
+        coins::Symbol,
         context::Context,
         plugins::{ChainId, ConvertSdkTx, DefaultPlugins, PaidCall},
         tendermint::client::HttpClient,
@@ -525,7 +521,6 @@ mod tests {
 
     use super::*;
     use orga::orga;
-    use orga_macros::build_call;
 
     #[orga]
     #[derive(Debug, Clone, Copy)]
@@ -541,7 +536,7 @@ mod tests {
     }
 
     impl BeginBlock for App {
-        fn begin_block(&mut self, ctx: &orga::plugins::BeginBlockCtx) -> Result<()> {
+        fn begin_block(&mut self, _ctx: &orga::plugins::BeginBlockCtx) -> Result<()> {
             self.count += 1;
 
             Ok(())

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -4,6 +4,8 @@ mod ics23;
 #[cfg(feature = "merk-full")]
 mod proofbuilder;
 #[cfg(feature = "merk-full")]
+pub mod state_sync;
+#[cfg(feature = "merk-full")]
 pub mod store;
 
 pub use client::Client;

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -4,7 +4,7 @@ mod ics23;
 #[cfg(feature = "merk-full")]
 mod proofbuilder;
 #[cfg(feature = "merk-full")]
-pub mod state_sync;
+pub mod snapshot;
 #[cfg(feature = "merk-full")]
 pub mod store;
 

--- a/src/merk/proofbuilder.rs
+++ b/src/merk/proofbuilder.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use super::snapshot::Snapshot;
 use super::MerkStore;
 use crate::store;
 use crate::store::Shared;
@@ -100,6 +101,12 @@ pub trait Prove {
 impl Prove for MerkStore {
     fn prove(&self, query: Query) -> Result<Vec<u8>> {
         Ok(self.merk().prove(query)?)
+    }
+}
+
+impl Prove for Snapshot {
+    fn prove(&self, query: Query) -> Result<Vec<u8>> {
+        Ok(self.checkpoint.borrow().prove(query)?)
     }
 }
 

--- a/src/merk/proofbuilder.rs
+++ b/src/merk/proofbuilder.rs
@@ -10,16 +10,24 @@ use store::Read;
 
 /// Records reads to a `MerkStore` and uses them to build a proof including all
 /// accessed keys.
-#[derive(Clone)]
 pub struct ProofBuilder<T> {
     store: Shared<T>,
     query: Rc<RefCell<Query>>,
 }
 
+impl<T> Clone for ProofBuilder<T> {
+    fn clone(&self) -> Self {
+        ProofBuilder {
+            store: self.store.clone(),
+            query: self.query.clone(),
+        }
+    }
+}
+
 impl<T: Prove> ProofBuilder<T> {
     /// Constructs a `ProofBuilder` which provides read access to data in the
     /// given `MerkStore`.
-    pub fn new(store: Shared<MerkStore>) -> Self {
+    pub fn new(store: Shared<T>) -> Self {
         ProofBuilder {
             store,
             query: Rc::new(RefCell::new(Query::new())),
@@ -31,8 +39,7 @@ impl<T: Prove> ProofBuilder<T> {
     pub fn build(self) -> Result<Vec<u8>> {
         let store = self.store.borrow();
         let query = self.query.take();
-
-        Ok(store.borrow().prove(query)?)
+        Ok(store.prove(query)?)
     }
 }
 

--- a/src/merk/proofbuilder.rs
+++ b/src/merk/proofbuilder.rs
@@ -40,7 +40,7 @@ impl<T: Prove> ProofBuilder<T> {
     pub fn build(self) -> Result<Vec<u8>> {
         let store = self.store.borrow();
         let query = self.query.take();
-        Ok(store.prove(query)?)
+        store.prove(query)
     }
 }
 

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -10,7 +10,7 @@ use tendermint_proto::v0_34::abci::{RequestLoadSnapshotChunk, Snapshot as AbciSn
 
 #[derive(Clone)]
 pub struct Snapshot {
-    checkpoint: Rc<RefCell<Merk>>,
+    pub(crate) checkpoint: Rc<RefCell<Merk>>,
     chunks: Rc<RefCell<Option<ChunkProducer<'static>>>>,
     length: u32,
     hash: Hash,

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::mem::transmute;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use tendermint_proto::abci::{RequestLoadSnapshotChunk, Snapshot as AbciSnapshot};
+use tendermint_proto::v0_34::abci::{RequestLoadSnapshotChunk, Snapshot as AbciSnapshot};
 
 #[derive(Clone)]
 pub struct Snapshot {
@@ -47,6 +47,10 @@ impl Read for Snapshot {
 
     fn get_next(&self, key: &[u8]) -> Result<Option<crate::store::KV>> {
         super::store::get_next(&self.checkpoint.borrow(), key)
+    }
+
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<crate::store::KV>> {
+        super::store::get_prev(&self.checkpoint.borrow(), key)
     }
 }
 
@@ -200,7 +204,7 @@ impl Snapshots {
             .map(|(height, snapshot)| {
                 Ok(AbciSnapshot {
                     chunks: snapshot.length,
-                    hash: snapshot.hash.to_vec(),
+                    hash: snapshot.hash.to_vec().into(),
                     height: *height,
                     ..Default::default()
                 })

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -109,7 +109,7 @@ pub struct Snapshots {
 impl Snapshots {
     pub fn new(path: &Path) -> Result<Self> {
         if !path.exists() {
-            std::fs::create_dir(&path).expect("Failed to create snapshot directory");
+            std::fs::create_dir(path).expect("Failed to create snapshot directory");
         }
 
         Ok(Self {

--- a/src/merk/state_sync.rs
+++ b/src/merk/state_sync.rs
@@ -1,0 +1,216 @@
+use crate::Result;
+use merk::{chunks::ChunkProducer, Hash, Merk};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::mem::transmute;
+use std::path::{Path, PathBuf};
+use tendermint_proto::abci::{RequestLoadSnapshotChunk, Snapshot as AbciSnapshot};
+
+struct Snapshot {
+    _checkpoint: Merk,
+    chunks: RefCell<Option<ChunkProducer<'static>>>,
+    length: u32,
+    hash: Hash,
+}
+
+impl Snapshot {
+    fn new(checkpoint: Merk) -> Result<Self> {
+        let chunks = checkpoint.chunks()?;
+        let chunks: ChunkProducer<'static> = unsafe { transmute(chunks) };
+
+        let length = chunks.len() as u32;
+        let hash = checkpoint.root_hash();
+
+        Ok(Self {
+            _checkpoint: checkpoint,
+            chunks: RefCell::new(Some(chunks)),
+            length,
+            hash,
+        })
+    }
+
+    fn chunk(&self, index: usize) -> Result<Vec<u8>> {
+        let mut chunks = self.chunks.borrow_mut();
+        let chunks = chunks.as_mut().unwrap();
+        let chunk = chunks.chunk(index)?;
+        Ok(chunk)
+    }
+}
+
+impl Drop for Snapshot {
+    fn drop(&mut self) {
+        // drop the self-referential ChunkProducer before the Merk instance
+        self.chunks.borrow_mut().take();
+    }
+}
+
+pub enum SnapshotFilter {
+    Interval {
+        interval: u64,
+        limit: u64,
+    },
+    SpecificHeight {
+        height: u64,
+        keep_until: Option<u64>,
+    },
+}
+
+impl SnapshotFilter {
+    pub fn interval(interval: u64, limit: u64) -> Self {
+        SnapshotFilter::Interval { interval, limit }
+    }
+
+    pub fn specific_height(height: u64, keep_until: Option<u64>) -> Self {
+        SnapshotFilter::SpecificHeight { height, keep_until }
+    }
+
+    pub fn should_create(&self, height: u64) -> bool {
+        match self {
+            SnapshotFilter::Interval { interval, .. } => height % interval == 0,
+            SnapshotFilter::SpecificHeight { height: h, .. } => height == *h,
+        }
+    }
+
+    pub fn should_keep(&self, ss_height: u64, cur_height: u64) -> bool {
+        match self {
+            SnapshotFilter::Interval { interval, limit } => {
+                ss_height % interval == 0 && cur_height - ss_height < interval * limit
+            }
+            SnapshotFilter::SpecificHeight { height, keep_until } => {
+                ss_height == *height && keep_until.map_or(true, |n| cur_height < n)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Snapshots {
+    snapshots: BTreeMap<u64, Snapshot>,
+    filters: Vec<SnapshotFilter>,
+    path: Path,
+}
+
+impl Snapshots {
+    pub fn new(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            std::fs::create_dir(&path).expect("Failed to create snapshot directory");
+        }
+
+        Ok(Self {
+            snapshots: BTreeMap::new(),
+            filters: vec![],
+            path: path.clone(),
+        })
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let mut snapshots = Self::new(path);
+
+        let snapshot_dir = snapshots.path.read_dir()?;
+        for entry in snapshot_dir {
+            let entry = entry?;
+            let path = entry.path();
+
+            // TODO: open read-only
+            let checkpoint = Merk::open(&path)?;
+            let snapshot = Snapshot::new(checkpoint)?;
+
+            let height_str = path.file_name().unwrap().to_str().unwrap();
+            let height: u64 = height_str.parse()?;
+            snapshots.snapshots.insert(height, snapshot);
+        }
+
+        Ok(snapshots)
+    }
+
+    pub fn with_filters(mut self, filters: Vec<SnapshotFilter>) -> Self {
+        self.filters = filters;
+        self
+    }
+
+    pub fn should_create_snapshot(&self, height: u64) -> bool {
+        height > 0
+            && self
+                .snapshot_filters
+                .iter()
+                .any(|f| f.should_create(height))
+    }
+
+    pub fn should_keep_snapshot(&self, ss_height: u64, cur_height: u64) -> bool {
+        self.snapshot_filters
+            .iter()
+            .any(|f| f.should_keep(ss_height, cur_height))
+    }
+
+    pub fn maybe_create_snapshot(&mut self, height: u64, merk: &Merk) -> Result<()> {
+        if !self.should_create_snapshot(height) {
+            return Ok(());
+        }
+        if self.snapshots.contains_key(&height) {
+            return Ok(());
+        }
+
+        let path = self.snapshot_path(height);
+        let checkpoint = merk.checkpoint(path)?;
+
+        let snapshot = Snapshot::new(checkpoint)?;
+        self.snapshots.insert(height, snapshot);
+
+        self.maybe_prune_snapshots()
+    }
+
+    pub fn maybe_prune_snapshots(&mut self) -> Result<()> {
+        let cur_height = self.height()?;
+
+        let remove_heights = self
+            .snapshots
+            .iter()
+            .filter_map(|(ss_height, _)| {
+                if self.should_keep_snapshot(*ss_height, cur_height) {
+                    None
+                } else {
+                    Some(*ss_height)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for ss_height in remove_heights {
+            self.snapshots.remove(&ss_height);
+
+            let path = self.snapshot_path(ss_height);
+            if path.exists() {
+                std::fs::remove_dir_all(path)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn snapshot_path(&self, height: u64) -> PathBuf {
+        self.path.join(height.to_string())
+    }
+
+    pub fn list_snapshots(&self) -> Result<Vec<Snapshot>> {
+        self.snapshots
+            .iter()
+            .map(|(height, snapshot)| {
+                Ok(AbciSnapshot {
+                    chunks: snapshot.length,
+                    hash: snapshot.hash.to_vec(),
+                    height: *height,
+                    ..Default::default()
+                })
+            })
+            .collect()
+    }
+
+    pub fn load_snapshot_chunk(&self, req: RequestLoadSnapshotChunk) -> Result<Vec<u8>> {
+        match self.snapshots.get(&req.height) {
+            Some(snapshot) => snapshot.chunk(req.chunk as usize),
+            // ABCI has no way to specify that we don't have the requested
+            // chunk, so we just return an empty one (and probably get banned by
+            // the client when they try to verify)
+            None => Ok(vec![]),
+        }
+    }
+}

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -267,8 +267,15 @@ impl ABCIStore for MerkStore {
         self.write(metadata)?;
         self.merk.as_mut().unwrap().flush()?;
 
+        let recent = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+            - header.time.unwrap().seconds
+            < 10;
+
         #[cfg(feature = "state-sync")]
-        if self.snapshots.should_create(height) {
+        if recent && self.snapshots.should_create(height) {
             let path = self.snapshots.path(height);
             let checkpoint = self.merk.as_ref().unwrap().checkpoint(path)?;
             self.snapshots.create(height, checkpoint)?;

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -26,7 +26,7 @@ pub struct MerkStore {
     merk: Option<Merk>,
     home: PathBuf,
     map: Option<Map>,
-    // snapshots: state_sync::Snapshots,
+    snapshots: state_sync::Snapshots,
     restorer: Option<Restorer>,
     target_snapshot: Option<Snapshot>,
 }

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -1,14 +1,9 @@
 use crate::abci::ABCIStore;
 use crate::error::{Error, Result};
 use crate::store::*;
-use merk::{
-    chunks::ChunkProducer, proofs::query::Map as ProofMap, restore::Restorer, rocksdb, tree::Tree,
-    BatchEntry, Hash, Merk, Op,
-};
-use std::cell::RefCell;
+use merk::{proofs::query::Map as ProofMap, restore::Restorer, tree::Tree, BatchEntry, Merk, Op};
 use std::{collections::BTreeMap, convert::TryInto};
 use std::{
-    mem::transmute,
     ops::Bound,
     path::{Path, PathBuf},
 };

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -258,7 +258,8 @@ impl ABCIStore for MerkStore {
         Ok(calc_app_hash(merk_root.as_slice()))
     }
 
-    fn commit(&mut self, height: u64) -> Result<()> {
+    fn commit(&mut self, header: tendermint_proto::v0_34::types::Header) -> Result<()> {
+        let height = header.height as u64;
         let height_bytes = height.to_be_bytes();
 
         let metadata = vec![(b"height".to_vec(), Some(height_bytes.to_vec()))];

--- a/src/plugins/query.rs
+++ b/src/plugins/query.rs
@@ -60,7 +60,7 @@ mod abci {
         T: BeginBlock + State,
     {
         fn begin_block(&mut self, ctx: &BeginBlockCtx) -> Result<()> {
-            self.inner.begin_block(ctx)
+            self.inner.borrow_mut().begin_block(ctx)
         }
     }
 
@@ -69,7 +69,7 @@ mod abci {
         T: EndBlock + State,
     {
         fn end_block(&mut self, ctx: &EndBlockCtx) -> Result<()> {
-            self.inner.end_block(ctx)
+            self.inner.borrow_mut().end_block(ctx)
         }
     }
 
@@ -90,7 +90,7 @@ mod abci {
             &self,
             request: &tendermint_proto::v0_34::abci::RequestQuery,
         ) -> Result<tendermint_proto::v0_34::abci::ResponseQuery> {
-            self.inner.abci_query(request)
+            self.inner.borrow().abci_query(request)
         }
     }
 }

--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -139,7 +139,7 @@ impl Write for BackingStore {
 
 impl BackingStore {
     #[cfg(feature = "merk-full")]
-    pub fn into_proof_builder(self) -> Result<ProofBuilder> {
+    pub fn into_proof_builder(self) -> Result<ProofBuilder<Shared<MerkStore>>> {
         match self {
             #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilder(builder) => Ok(builder),

--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -183,6 +183,17 @@ impl BackingStore {
     }
 
     #[cfg(feature = "merk-full")]
+    pub fn into_proof_builder_snapshot(self) -> Result<ProofBuilder<Snapshot>> {
+        match self {
+            #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderSnapshot(builder) => Ok(builder),
+            _ => Err(Error::Downcast(
+                "Failed to downcast backing store to proof builder snapshot".into(),
+            )),
+        }
+    }
+
+    #[cfg(feature = "merk-full")]
     pub fn into_wrapped_merk(self) -> Result<WrappedMerkStore> {
         match self {
             #[cfg(feature = "merk-full")]

--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -21,7 +21,9 @@ pub enum BackingStore {
     #[cfg(feature = "merk-full")]
     WrappedMerk(WrappedMerkStore),
     #[cfg(feature = "merk-full")]
-    ProofBuilder(ProofBuilder),
+    ProofBuilder(ProofBuilder<MerkStore>),
+    // #[cfg(feature = "merk-full")]
+    // ProofBuilderSnapshot(ProofBuilder<MerkSnapshot>),
     #[cfg(feature = "merk-full")]
     Merk(Shared<MerkStore>),
     #[cfg(feature = "merk")]

--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -129,7 +129,7 @@ impl Write for BackingStore {
                 panic!("put() is not implemented for ProofBuilder")
             }
             #[cfg(feature = "merk-full")]
-            BackingStore::ProofBuilderSnapshot(ref builder) => {
+            BackingStore::ProofBuilderSnapshot(_) => {
                 panic!("put() is not implemented for ProofBuilderSnapshot")
             }
             #[cfg(feature = "merk")]
@@ -155,7 +155,7 @@ impl Write for BackingStore {
                 panic!("delete() is not implemented for ProofBuilder")
             }
             #[cfg(feature = "merk-full")]
-            BackingStore::ProofBuilderSnapshot(ref builder) => {
+            BackingStore::ProofBuilderSnapshot(_) => {
                 panic!("delete() is not implemented for ProofBuilderSnapshot")
             }
             #[cfg(feature = "merk-full")]

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -88,7 +88,6 @@ impl<S> Clone for Store<S> {
     }
 }
 
-#[orga]
 impl<S: Read> Store<S> {
     /// Creates a new `Store` with no prefix, with `backing` as its backing
     /// store.
@@ -138,7 +137,10 @@ impl<S: Read> Store<S> {
     {
         Read::into_iter(self.clone(), bounds)
     }
+}
 
+#[orga]
+impl Store {
     #[query]
     pub fn get_query(&self, key: LengthVec<u8, u8>) -> Result<Option<Vec<u8>>> {
         self.store.get(key.as_slice())


### PR DESCRIPTION
This PR adds support for querying the state at a given height when using the SDK-compatible ABCI query handlers. Every query will be resolved against a `MerkStore` snapshot for the specified height, erroring if one does not exist at that height. Note that native queries don't have a way to specify a height so historical queries won't work for them yet, but most of the groundwork is now laid out so that can be done eventually.

Filters can also be specified to define when snapshots should be created and how long they should be kept, defaulting to the state sync filters (one snapshot every 1,000 blocks, held for 4,000 blocks, and one snapshot at height 2 held indefinitely), in addition to now creating a snapshot every block and retaining it for 20 blocks.

These filters should eventually be configured by the node operator somehow, but are currently just statically defined in the code.