### PR TITLE
ABCI context fix

### DIFF
--- a/src/plugins/abci.rs
+++ b/src/plugins/abci.rs
@@ -286,6 +286,8 @@ mod full {
                     if res.is_ok() {
                         self.events
                             .replace(Context::resolve::<Events>().unwrap().events.clone());
+                    } else {
+                        Context::remove::<Validators>();
                     }
                     Context::remove::<Events>();
                     res?;
@@ -297,6 +299,8 @@ mod full {
                     if res.is_ok() {
                         self.events
                             .replace(Context::resolve::<Events>().unwrap().events.clone());
+                    } else {
+                        Context::remove::<Validators>();
                     }
                     Context::remove::<Events>();
                     res?;


### PR DESCRIPTION
An issue was recently introduced which causes a panic on the block after a failed call, since the ABCI `Validators` context was never being removed if a call failed, but still held a borrow of the store. This PR cleans up that context even if the call fails.