### PR TITLE
Fix panic corruption

### DIFF
--- a/src/plugins/abci.rs
+++ b/src/plugins/abci.rs
@@ -264,6 +264,7 @@ mod full {
             use ABCICall::*;
             let validators =
                 Validators::new(self.current_vp.clone(), self.cons_key_by_op_addr.clone());
+            let context_remover = ContextRemover;
             Context::add(validators);
             let create_time_ctx = |time: &Option<Timestamp>| {
                 if let Some(timestamp) = time {
@@ -335,8 +336,22 @@ mod full {
             }
 
             self.build_updates()?;
-            Context::remove::<Validators>();
+            context_remover.remove();
             Ok(())
+        }
+    }
+
+    struct ContextRemover;
+
+    impl ContextRemover {
+        fn remove(&self) {
+            Context::remove::<Validators>();
+        }
+    }
+
+    impl Drop for ContextRemover {
+        fn drop(&mut self) {
+            self.remove();
         }
     }
 


### PR DESCRIPTION
This PR ensures the ABCI validators context instance is properly cleaned up, even in the event of a panic or error result in the inner call code.