### PR TITLE
Fix building tests with default features

### DIFF
--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -212,7 +212,10 @@ mod tests {
     }
 
     fn create_foo_v0_store() -> Result<Store> {
+        #[cfg(any(feature = "merk", feature = "merk-verify"))]
         let mut store = Store::new(DefaultBackingStore::MapStore(Shared::new(MapStore::new())));
+        #[cfg(all(not(feature = "merk"), not(feature = "merk-verify")))]
+        let mut store = Store::new(DefaultBackingStore::new(MapStore::new()));
 
         let mut foo = FooV0 {
             bar: 42,


### PR DESCRIPTION
This PR fixes `cargo test` (we had just been always running with `--all-features` which does build correctly). This fix will unlock other PRs since they will now pass CI.