### PR TITLE
Migration QA

### DIFF
--- a/macros/src/orga.rs
+++ b/macros/src/orga.rs
@@ -76,6 +76,7 @@ impl OrgaSubStruct {
             quote! { ::orga::encoding::VersionedEncoding },
         );
         maybe_add("State", quote! { ::orga::state::State });
+        maybe_add("Serialize", quote! { ::orga::serde::Serialize });
 
         if self.is_last {
             maybe_add("Call", quote! { ::orga::call::Call });

--- a/src/coins/amount.rs
+++ b/src/coins/amount.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 
 #[orga]
 #[derive(Debug, Clone, Copy)]
+#[serde(transparent)]
 pub struct Amount {
     pub(crate) value: u64,
 }

--- a/src/coins/decimal.rs
+++ b/src/coins/decimal.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 
 #[orga(simple)]
 #[derive(Copy, Debug)]
+#[serde(transparent)]
 pub struct Decimal {
     pub(crate) value: NumDecimal,
 }

--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -5,12 +5,17 @@ use crate::encoding::{Decode, Encode, Terminated};
 use crate::orga;
 use crate::state::State;
 use crate::{Error, Result};
+use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Drop, RangeBounds};
 
 #[orga]
+#[serde(bound(
+    serialize = "K: Serialize + Decode + Clone, V: Serialize",
+    deserialize = "K: Deserialize<'de> + Decode + Clone, V: Deserialize<'de>",
+))]
 pub struct Pool<K, V, S>
 where
     K: Terminated + Encode + Decode + Clone,

--- a/src/coins/staking/mod.rs
+++ b/src/coins/staking/mod.rs
@@ -32,7 +32,7 @@ const UNBONDING_SECONDS: u64 = 10; // 10 seconds
 const UNBONDING_SECONDS: u64 = 60 * 60 * 24 * 14; // 2 weeks
 const EDIT_INTERVAL_SECONDS: u64 = 60 * 60 * 24; // 1 day
 
-#[derive(Call, Query, Default, Client, MigrateFrom)]
+#[derive(Call, Query, Default, Client, MigrateFrom, Serialize)]
 pub struct Staking<S: Symbol> {
     validators: Pool<Address, Validator<S>, S>,
     #[call]

--- a/src/collections/deque.rs
+++ b/src/collections/deque.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use super::map::{ChildMut, Map, ReadOnly, Ref};
 use crate::call::Call;
 use crate::client::Client;
@@ -10,7 +12,11 @@ use crate::state::State;
 use crate::store::Store;
 use crate::Result;
 
-#[derive(Query, Encode, Decode)]
+#[derive(Query, Encode, Decode, Serialize)]
+#[serde(bound(
+    serialize = "T: Serialize + State",
+    deserialize = "T: Deserialize<'de> + State",
+))]
 pub struct Deque<T> {
     meta: Meta,
     map: Map<u64, T>,

--- a/src/collections/entry_map.rs
+++ b/src/collections/entry_map.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use super::map::Iter as MapIter;
 use super::map::Map;
 use super::map::ReadOnly;
@@ -13,7 +15,11 @@ use crate::state::*;
 use crate::store::*;
 use crate::Result;
 
-#[derive(Query, Call, Encode, Decode)]
+#[derive(Query, Call, Encode, Decode, Serialize)]
+#[serde(bound(
+    serialize = "T::Key: Serialize + Terminated + Clone, T::Value: Serialize + State",
+    deserialize = "T::Key: Deserialize<'de> + Terminated + Clone, T::Value: Deserialize<'de> + State",
+))]
 
 pub struct EntryMap<T: Entry> {
     map: Map<T::Key, T::Value>,

--- a/src/collections/entry_map.rs
+++ b/src/collections/entry_map.rs
@@ -201,18 +201,35 @@ where
     T2::Key: Encode + Terminated,
     T2::Value: State,
 {
-    fn migrate_from(other: EntryMap<T1>) -> Result<Self> {
+    fn migrate_from(mut other: EntryMap<T1>) -> Result<Self> {
         // TODO: clone bound shouldn't be required on T1::Value, but there's currently no
         // way to access the inner map's store, so we need the
         // clone bound to create the entry map's iterator
-        let mut entry_map = Self::default();
+
+        let mut map = Self::default();
+        let mut old_keys = vec![];
         for entry in other.map.iter()? {
-            let (k, v) = entry?;
-            let entry = T1::from_entry((k.clone(), v.clone()));
-            entry_map.insert(entry.migrate_into()?)?;
+            let (key, _value) = entry?;
+            old_keys.push(key.clone());
         }
 
-        Ok(entry_map)
+        for key in old_keys {
+            let old_key_bytes = key.encode()?;
+            let mut value_bytes = vec![];
+            let value = other.map.remove(key.clone())?.unwrap().into_inner();
+            value.flush(&mut value_bytes)?;
+            let value = T1::Value::load(
+                other.map.store.sub(old_key_bytes.as_slice()),
+                &mut value_bytes.as_slice(),
+            )?;
+            let entry = T1::from_entry((key, value));
+            let new_entry = entry.migrate_into()?;
+            map.insert(new_entry)?;
+        }
+        let mut out = vec![];
+        other.flush(&mut out)?;
+
+        Ok(map)
     }
 }
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -88,7 +88,7 @@ impl<K> Eq for MapKey<K> {}
 /// changes to the backing store.
 #[derive(Query, Call)]
 pub struct Map<K, V> {
-    store: Store,
+    pub(super) store: Store,
     children: BTreeMap<MapKey<K>, Option<V>>,
 }
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -6,6 +6,7 @@ use std::ops::{Bound, Deref, DerefMut, RangeBounds};
 
 use crate::call::Call;
 use crate::client::{AsyncCall, Client as ClientTrait};
+use crate::coins::Address;
 use crate::migrate::{MigrateFrom, MigrateInto};
 use crate::query::Query;
 use crate::state::State;
@@ -230,18 +231,12 @@ where
         }
 
         for key in old_keys.iter() {
-            let old_key_bytes = key.encode()?;
-            let mut value_bytes = vec![];
             let value = other.remove(key.clone())?.unwrap().into_inner();
-            value.flush(&mut value_bytes)?;
-            let value = V1::load(
-                other.store.sub(old_key_bytes.as_slice()),
-                &mut value_bytes.as_slice(),
-            )?;
             let new_key = key.clone().migrate_into()?;
             let new_value = value.migrate_into()?;
             map.insert(new_key, new_value)?;
         }
+
         let mut out = vec![];
         other.flush(&mut out)?;
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -12,6 +12,7 @@ use crate::state::State;
 use crate::store::*;
 use crate::{Error, Result};
 use ed::*;
+use serde::Serialize;
 
 #[derive(Clone, Debug)]
 pub struct MapKey<K> {
@@ -427,6 +428,25 @@ where
         }
 
         Ok(())
+    }
+}
+
+impl<K: Serialize, V: Serialize> Serialize for Map<K, V>
+where
+    K: Encode + Decode + Terminated + Clone,
+    V: State,
+{
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::{Error, SerializeSeq};
+        let mut seq = serializer.serialize_seq(None)?;
+        for entry in self.iter().map_err(Error::custom)? {
+            let (key, value) = entry.map_err(Error::custom)?;
+            seq.serialize_element(&(&*key, &*value))?;
+        }
+        seq.end()
     }
 }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -10,6 +10,7 @@ pub mod decoder;
 pub mod encoder;
 
 use derive_more::{Deref, DerefMut, Into};
+use serde::Serialize;
 use std::convert::{TryFrom, TryInto};
 
 #[derive(
@@ -27,12 +28,14 @@ use std::convert::{TryFrom, TryInto};
     Hash,
     Eq,
     Client,
+    Serialize,
 )]
 pub struct LengthVec<P, T>
 where
     P: Encode + Decode + TryInto<usize> + Terminated + Clone,
     T: Encode + Decode + Terminated,
 {
+    #[serde(skip)]
     len: P,
 
     #[deref]

--- a/src/ibc/transfer.rs
+++ b/src/ibc/transfer.rs
@@ -32,6 +32,7 @@ use ibc::timestamp::Timestamp;
 use ibc::Height;
 use ibc_proto::ibc::core::channel::v1::PacketState;
 use ripemd::Digest;
+use serde::Serialize;
 use std::str::FromStr;
 
 use super::{Adapter, Lunchbox};
@@ -554,7 +555,7 @@ impl TransferModule {
     }
 }
 
-#[derive(State, Encode, Decode, Clone, Debug, Describe, MigrateFrom)]
+#[derive(State, Encode, Decode, Clone, Debug, Describe, MigrateFrom, Serialize)]
 pub struct Dynom(pub LengthVec<u8, u8>);
 
 impl FromStr for Dynom {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub use async_trait::async_trait;
 pub use error::*;
 pub use futures_lite::future::Boxed as BoxFuture;
 pub use orga_macros as macros;
+pub use serde;
 pub use serde_json::Value as JsonValue;
 
 pub mod prelude {

--- a/src/plugins/abci.rs
+++ b/src/plugins/abci.rs
@@ -8,6 +8,7 @@ use crate::query::Query;
 use crate::state::State;
 use crate::store::Store;
 use crate::{compat_mode, Error, Result};
+use serde::Serialize;
 use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -42,13 +43,20 @@ pub struct ValidatorEntry {
 
 type UpdateMap = Map<[u8; 32], Adapter<ValidatorUpdate>>;
 
+#[derive(Serialize)]
 pub struct ABCIPlugin<T> {
     pub inner: T,
+    #[serde(skip)]
     pub(crate) validator_updates: Option<HashMap<[u8; 32], ValidatorUpdate>>,
+    #[serde(skip)]
     updates: UpdateMap,
+    #[serde(skip)]
     time: Option<Timestamp>,
+    #[serde(skip)]
     pub(crate) events: Option<Vec<Event>>,
+    #[serde(skip)]
     current_vp: Rc<RefCell<Option<EntryMap<ValidatorEntry>>>>,
+    #[serde(skip)]
     cons_key_by_op_addr: Rc<RefCell<Option<OperatorMap>>>,
 }
 

--- a/src/plugins/chain_commitment.rs
+++ b/src/plugins/chain_commitment.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use super::{sdk_compat::sdk::Tx as SdkTx, ConvertSdkTx};
 use crate::call::Call as CallTrait;
 use crate::client::{AsyncCall, AsyncQuery, Client as ClientTrait};
@@ -10,7 +12,7 @@ use crate::{Error, Result};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Encode, Decode, Default, State)]
+#[derive(Encode, Decode, Default, State, Serialize)]
 #[state(transparent)]
 pub struct ChainCommitmentPlugin<T, const ID: &'static str> {
     inner: T,

--- a/src/plugins/nonce.rs
+++ b/src/plugins/nonce.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use super::{sdk_compat::sdk::Tx as SdkTx, ConvertSdkTx, Signer};
 use crate::call::Call;
 use crate::client::Client;
@@ -14,7 +16,7 @@ use std::ops::{Deref, DerefMut};
 
 const NONCE_INCREASE_LIMIT: u64 = 1000;
 
-#[derive(State, Encode, Decode, Default)]
+#[derive(State, Encode, Decode, Default, Serialize)]
 pub struct NoncePlugin<T: State> {
     map: Map<Address, u64>,
     inner: T,

--- a/src/plugins/payable.rs
+++ b/src/plugins/payable.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use super::sdk_compat::{sdk::Tx as SdkTx, ConvertSdkTx};
 use crate::call::Call;
 use crate::client::{AsyncCall, AsyncQuery, Client};
@@ -14,7 +16,7 @@ use std::ops::{Deref, DerefMut};
 
 const MAX_SUBCALL_LEN: u32 = 200_000;
 
-#[derive(State, Encode, Decode, Default)]
+#[derive(State, Encode, Decode, Default, Serialize)]
 pub struct PayablePlugin<T> {
     inner: T,
 }

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -16,7 +16,7 @@ pub const NATIVE_CALL_FLAG: u8 = 0xff;
 
 // TODO: add version 1 so that plugin is transparent on `inner`
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Serialize)]
 pub struct SdkCompatPlugin<S, T: State> {
     pub(crate) symbol: PhantomData<S>,
     pub(crate) inner: T,
@@ -509,6 +509,7 @@ impl<T: Client<SdkCompatAdapter<T, U, S>>, U: Clone, S> DerefMut for SdkCompatCl
     }
 }
 
+use serde::Serialize;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsValue;
 

--- a/src/plugins/signer.rs
+++ b/src/plugins/signer.rs
@@ -15,7 +15,7 @@ use secp256k1::{ecdsa::Signature, Message, PublicKey, Secp256k1, SecretKey};
 use serde::Serialize;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Default, Encode, Decode, State)]
+#[derive(Default, Encode, Decode, State, Serialize)]
 #[state(transparent)]
 pub struct SignerPlugin<T> {
     pub(crate) inner: T,


### PR DESCRIPTION
- Added `Serialize` to built-in state types and derive it in the `#[orga]` macro for debugging state. Currently not deriving `Deserialize`, and this should be behind a feature flag since this is only used for specific occasions and probably hurts compile times.
- Fixed `EntryMap` migration which was not removing old data.
- Fixed `Map` migration in compat mode which was writing out the encoded bytes for migrated children, then loading them as the un-migrated version.
- Added assertions to help prevent similarly incorrect migrations (ensures all key/value bytes are consumed when decoding map children).