### PR TITLE
Reverse iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 abci2 = { git = "https://github.com/nomic-io/abci2", rev="e9d12675bcc8baffe45c976cd6d2a7b76b916da7", optional = true }
-merk = { git = "https://github.com/nomic-io/merk", rev = "8009dff26de5718eec709d3aea6d71f7c5188adb", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "b911313ba188e8d83a04a69fb150734605d0e107", optional = true, default-features = false }
 tendermint-rpc = { version = "=0.23.7", features = ["http-client"], optional = true }
 tendermint = { version = "=0.23.7", optional = true }
 tendermint-proto = { version = "=0.23.7" }

--- a/src/abci/mod.rs
+++ b/src/abci/mod.rs
@@ -512,6 +512,10 @@ mod server {
         fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
             self.store.get_next(key)
         }
+
+        fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+            self.store.get_prev(key)
+        }
     }
 
     impl Write for MemStore {

--- a/src/collections/deque.rs
+++ b/src/collections/deque.rs
@@ -250,6 +250,18 @@ where
     }
 }
 
+impl<'a, T> DoubleEndedIterator for Iter<'a, T>
+where
+    T: State,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.map_iter.next_back().map(|entry| match entry {
+            Ok(entry) => Ok(entry.1),
+            Err(err) => Err(err),
+        })
+    }
+}
+
 #[allow(unused_imports)]
 mod test {
     use super::{Deque, Map, Meta};

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -361,7 +361,7 @@ where
         let store_iter = StoreNextIter::new(&self.store, encoded_range)?;
 
         Ok(Iter {
-            parent: &self,
+            parent: self,
             map_iter,
             store_iter,
         })
@@ -592,38 +592,15 @@ where
                 .parent
                 .children
                 .range((
-                    maybe_front_entry.map_or(Bound::Included(back_entry.0.clone()), |(k, _)| {
-                        Bound::Included(k)
-                    }),
-                    Bound::Included(back_entry.0.clone()),
+                    maybe_front_entry
+                        .map_or(Bound::Included(back_entry.0), |(k, _)| Bound::Included(k)),
+                    Bound::Included(back_entry.0),
                 ))
                 .peekable();
 
             back_entry
         })
     }
-}
-
-fn maybe_debug<T>(t: T) -> String {
-    MaybeDebugWrapper(t).maybe_debug()
-}
-
-struct MaybeDebugWrapper<T>(T);
-
-impl<T> MaybeDebug for MaybeDebugWrapper<T> {
-    default fn maybe_debug(&self) -> String {
-        "(no debug)".to_string()
-    }
-}
-
-impl<T: std::fmt::Debug> MaybeDebug for MaybeDebugWrapper<T> {
-    fn maybe_debug(&self) -> String {
-        format!("{:?}", self.0)
-    }
-}
-
-trait MaybeDebug {
-    fn maybe_debug(&self) -> String;
 }
 
 impl<'a, K, V> Iterator for Iter<'a, K, V>
@@ -683,7 +660,7 @@ fn decrement_bytes(mut bytes: Vec<u8>) -> Option<Vec<u8>> {
         }
     }
 
-    if bytes.len() > 0 {
+    if bytes.is_empty() {
         bytes.pop();
         Some(bytes)
     } else {
@@ -1260,7 +1237,7 @@ mod tests {
 
     #[test]
     fn iter_merge_next_map_only() {
-        let (store, mut map) = setup();
+        let (_, mut map) = setup();
 
         map.entry(12).unwrap().or_insert(24).unwrap();
         map.entry(13).unwrap().or_insert(26).unwrap();

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -584,6 +584,7 @@ struct StoreNextIter<'a, S: Default + Read> {
     end_key: Bound<Vec<u8>>,
 }
 
+// TODO: dedupe this with the same code in Store
 fn increment_bytes(mut bytes: Vec<u8>) -> Vec<u8> {
     for byte in bytes.iter_mut().rev() {
         if *byte == 255 {

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -358,10 +358,10 @@ where
             encode_bound(range.start_bound())?,
             encode_bound(range.end_bound())?,
         );
-        let store_iter = StoreNextIter::new(&self.store, encoded_range)?.peekable();
+        let store_iter = StoreNextIter::new(&self.store, encoded_range)?;
 
         Ok(Iter {
-            parent_store: &self.store,
+            parent: &self,
             map_iter,
             store_iter,
         })
@@ -454,9 +454,9 @@ where
     K: Decode + Encode + Terminated,
     V: State,
 {
-    parent_store: &'a Store,
+    parent: &'a Map<K, V>,
     map_iter: Peekable<btree_map::Range<'a, MapKey<K>, Option<V>>>,
-    store_iter: Peekable<StoreNextIter<'a, Store>>,
+    store_iter: StoreNextIter<'a, Store>,
 }
 
 impl<'a, K, V> Iter<'a, K, V>
@@ -464,18 +464,36 @@ where
     K: Encode + Decode + Terminated,
     V: State,
 {
-    fn iter_merge_next(&mut self) -> Result<Option<(Ref<'a, K>, Ref<'a, V>)>> {
+    fn iter_merge_next(&mut self, forward: bool) -> Result<Option<(Ref<'a, K>, Ref<'a, V>)>> {
         loop {
-            let has_map_entry = self.map_iter.peek().is_some();
-            let has_backing_entry = self.store_iter.peek().is_some();
+            let (map_entry, backing_entry) = if forward {
+                (self.map_iter.peek().cloned(), self.store_iter.peek())
+            } else {
+                (self.peek_map_back(), self.store_iter.peek_back())
+            };
 
-            return Ok(match (has_map_entry, has_backing_entry) {
+            let mut map_next = || {
+                if forward {
+                    self.map_iter.next()
+                } else {
+                    self.map_iter.next_back()
+                }
+            };
+            let mut store_next = || {
+                if forward {
+                    self.store_iter.next()
+                } else {
+                    self.store_iter.next_back()
+                }
+            };
+
+            return Ok(match (map_entry, backing_entry) {
                 // consumed both iterators, end here
-                (false, false) => None,
+                (None, None) => None,
 
                 // consumed backing iterator, still have map values
-                (true, false) => {
-                    match self.map_iter.next().unwrap() {
+                (Some(_), None) => {
+                    match map_next().unwrap() {
                         // map value has not been deleted, emit value
                         (key, Some(value)) => {
                             Some((Ref::Borrowed(&key.inner), Ref::Borrowed(value)))
@@ -487,10 +505,9 @@ where
                 }
 
                 // consumed map iterator, still have backing values
-                (false, true) => {
-                    let entry = self
-                        .store_iter
-                        .next()
+                (None, Some(res)) => {
+                    res?;
+                    let entry = store_next()
                         .transpose()?
                         .expect("Peek ensures this arm is unreachable");
 
@@ -500,7 +517,7 @@ where
 
                     let mut value_bytes = entry.1.as_slice();
                     let value =
-                        V::load(self.parent_store.sub(entry.0.as_slice()), &mut value_bytes)?;
+                        V::load(self.parent.store.sub(entry.0.as_slice()), &mut value_bytes)?;
                     debug_assert!(
                         value_bytes.is_empty(),
                         "Value had leftover bytes after decode"
@@ -510,9 +527,9 @@ where
                 }
 
                 // merge values from both iterators
-                (true, true) => {
-                    let map_key = self.map_iter.peek().unwrap().0;
-                    let backing_key = match self.store_iter.peek().unwrap() {
+                (Some(map_entry), Some(store_res)) => {
+                    let map_key = map_entry.0;
+                    let backing_key = match store_res {
                         Err(_) => {
                             return Err(Error::Store("Backing key does not exist".into()));
                         }
@@ -531,13 +548,15 @@ where
                     //so compare backing_key with map_key.inner_bytes
                     let key_cmp = map_key.inner_bytes.cmp(backing_key);
 
-                    // map_key > backing_key, emit the backing entry
-                    if key_cmp == Ordering::Greater {
-                        let entry = self.store_iter.next().unwrap()?;
+                    // map_key is past backing_key, emit the backing entry
+                    if (forward && key_cmp == Ordering::Greater)
+                        || (!forward && key_cmp == Ordering::Less)
+                    {
+                        let entry = store_next().unwrap()?;
 
                         let mut value_bytes = entry.1.as_slice();
                         let value =
-                            V::load(self.parent_store.sub(entry.0.as_slice()), &mut value_bytes)?;
+                            V::load(self.parent.store.sub(entry.0.as_slice()), &mut value_bytes)?;
                         debug_assert!(
                             value_bytes.is_empty(),
                             "Value had leftover bytes after decode"
@@ -548,11 +567,11 @@ where
 
                     // map_key == backing_key, map entry shadows backing entry
                     if key_cmp == Ordering::Equal {
-                        self.store_iter.next().transpose()?;
+                        store_next().transpose()?;
                     }
 
-                    // map_key < backing_key
-                    match self.map_iter.next().unwrap() {
+                    // map_key is before or at backing_key
+                    match map_next().unwrap() {
                         (key, Some(value)) => {
                             Some((Ref::Borrowed(&key.inner), Ref::Borrowed(value)))
                         }
@@ -564,6 +583,47 @@ where
             });
         }
     }
+
+    fn peek_map_back(&mut self) -> Option<(&'a MapKey<K>, &'a Option<V>)> {
+        self.map_iter.next_back().map(|back_entry| {
+            let maybe_front_entry = self.map_iter.next();
+
+            self.map_iter = self
+                .parent
+                .children
+                .range((
+                    maybe_front_entry.map_or(Bound::Included(back_entry.0.clone()), |(k, _)| {
+                        Bound::Included(k)
+                    }),
+                    Bound::Included(back_entry.0.clone()),
+                ))
+                .peekable();
+
+            back_entry
+        })
+    }
+}
+
+fn maybe_debug<T>(t: T) -> String {
+    MaybeDebugWrapper(t).maybe_debug()
+}
+
+struct MaybeDebugWrapper<T>(T);
+
+impl<T> MaybeDebug for MaybeDebugWrapper<T> {
+    default fn maybe_debug(&self) -> String {
+        "(no debug)".to_string()
+    }
+}
+
+impl<T: std::fmt::Debug> MaybeDebug for MaybeDebugWrapper<T> {
+    fn maybe_debug(&self) -> String {
+        format!("{:?}", self.0)
+    }
+}
+
+trait MaybeDebug {
+    fn maybe_debug(&self) -> String;
 }
 
 impl<'a, K, V> Iterator for Iter<'a, K, V>
@@ -574,13 +634,23 @@ where
     type Item = Result<(Ref<'a, K>, Ref<'a, V>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter_merge_next().transpose()
+        self.iter_merge_next(true).transpose()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
+where
+    K: Decode + Encode + Terminated,
+    V: State,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter_merge_next(false).transpose()
     }
 }
 
 struct StoreNextIter<'a, S: Default + Read> {
     store: &'a S,
-    next_key: Option<Vec<u8>>,
+    next_key: Bound<Vec<u8>>,
     end_key: Bound<Vec<u8>>,
 }
 
@@ -603,34 +673,38 @@ fn increment_bytes(mut bytes: Vec<u8>) -> Vec<u8> {
     bytes
 }
 
-impl<'a, S: Default + Read> StoreNextIter<'a, S> {
-    fn new<B: RangeBounds<Vec<u8>>>(store: &'a S, range: B) -> Result<Self> {
-        let next_key = match range.start_bound() {
-            Bound::Included(inner) => Some(inner.encode()?),
-            Bound::Excluded(inner) => Some(increment_bytes(inner.encode()?)),
-            Bound::Unbounded => None,
-        };
+fn decrement_bytes(mut bytes: Vec<u8>) -> Option<Vec<u8>> {
+    for byte in bytes.iter_mut().rev() {
+        if *byte == 0 {
+            *byte = 255;
+        } else {
+            *byte -= 1;
+            return Some(bytes);
+        }
+    }
 
-        let end_key = encode_bound(range.end_bound())?;
-
-        Ok(StoreNextIter {
-            store,
-            next_key,
-            end_key,
-        })
+    if bytes.len() > 0 {
+        bytes.pop();
+        Some(bytes)
+    } else {
+        None
     }
 }
 
-impl<'a, S: Default + Read> Iterator for StoreNextIter<'a, S> {
-    type Item = Result<(Vec<u8>, Vec<u8>)>;
+impl<'a, S: Default + Read> StoreNextIter<'a, S> {
+    pub fn new<B: RangeBounds<Vec<u8>>>(store: &'a S, range: B) -> Result<Self> {
+        Ok(StoreNextIter {
+            store,
+            next_key: encode_bound(range.start_bound())?,
+            end_key: encode_bound(range.end_bound())?,
+        })
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    pub fn peek(&self) -> Option<Result<(Vec<u8>, Vec<u8>)>> {
         let get_res = match self.next_key.as_ref() {
-            Some(key) => self.store.get_next_inclusive(key.as_slice()),
-
-            // this will be None if the iter had an unbounded start range. start
-            // iterating from beginning of keyspace (empty key), exclusive
-            None => self.store.get_next(&[]),
+            Bound::Included(key) => self.store.get_next_inclusive(key.as_slice()),
+            Bound::Excluded(key) => self.store.get_next(key.as_slice()),
+            Bound::Unbounded => self.store.get_next(&[]),
         };
 
         let (key, value) = match get_res {
@@ -640,21 +714,56 @@ impl<'a, S: Default + Read> Iterator for StoreNextIter<'a, S> {
         };
 
         match &self.end_key {
-            Bound::Excluded(end) => {
-                if key >= *end {
-                    return None;
-                }
-            }
-            Bound::Included(end) => {
-                if key > *end {
-                    return None;
-                }
-            }
+            Bound::Excluded(end) if key >= *end => return None,
+            Bound::Included(end) if key > *end => return None,
             _ => {}
         };
 
-        self.next_key = Some(increment_bytes(key.clone()));
         Some(Ok((key, value)))
+    }
+
+    pub fn peek_back(&self) -> Option<Result<(Vec<u8>, Vec<u8>)>> {
+        let get_res = match self.end_key.as_ref() {
+            Bound::Included(key) => self.store.get_prev_inclusive(Some(key.as_slice())),
+            Bound::Excluded(key) => self.store.get_prev(Some(key.as_slice())),
+            Bound::Unbounded => self.store.get_prev(None),
+        };
+
+        let (key, value) = match get_res {
+            Err(e) => return Some(Err(e)),
+            Ok(None) => return None,
+            Ok(Some((key, value))) => (key, value),
+        };
+
+        match &self.next_key {
+            Bound::Excluded(end) if key <= *end => return None,
+            Bound::Included(end) if key < *end => return None,
+            _ => {}
+        };
+
+        Some(Ok((key, value)))
+    }
+}
+
+impl<'a, S: Default + Read> Iterator for StoreNextIter<'a, S> {
+    type Item = Result<(Vec<u8>, Vec<u8>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.peek()?.map(|(key, value)| {
+            self.next_key = Bound::Included(increment_bytes(key.clone()));
+            (key, value)
+        }))
+    }
+}
+
+impl<'a, S: Default + Read> DoubleEndedIterator for StoreNextIter<'a, S> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        Some(self.peek_back()?.map(|(key, value)| {
+            self.end_key = decrement_bytes(key.clone())
+                .map(Bound::Included)
+                .unwrap_or(Bound::Excluded(vec![]));
+            (key, value)
+        }))
     }
 }
 
@@ -1158,15 +1267,15 @@ mod tests {
         map.entry(14).unwrap().or_insert(28).unwrap();
 
         let map_iter = map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&map.store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&map.store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 12);
@@ -1175,7 +1284,7 @@ mod tests {
             None => panic!("Expected Some"),
         }
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 13);
@@ -1184,7 +1293,7 @@ mod tests {
             None => panic!("Expected Some"),
         }
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 14);
@@ -1193,7 +1302,7 @@ mod tests {
             None => panic!("Expected Some"),
         }
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert!(iter_next.is_none());
     }
 
@@ -1211,27 +1320,27 @@ mod tests {
         let read_map: Map<u32, u32> = Map::with_store(store.clone()).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert_eq!(*iter_next.as_ref().unwrap().0, 12);
         assert_eq!(*iter_next.as_ref().unwrap().1, 24);
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert_eq!(*iter_next.as_ref().unwrap().0, 13);
         assert_eq!(*iter_next.as_ref().unwrap().1, 26);
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert_eq!(*iter_next.as_ref().unwrap().0, 14);
         assert_eq!(*iter_next.as_ref().unwrap().1, 28);
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert!(iter_next.is_none());
     }
 
@@ -1249,15 +1358,15 @@ mod tests {
         read_map.insert(12, 26).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 12);
@@ -1281,15 +1390,15 @@ mod tests {
         read_map.remove(12).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         assert!(iter_next.is_none());
     }
 
@@ -1307,15 +1416,15 @@ mod tests {
         read_map.entry(14).unwrap().or_insert(28).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 12);
@@ -1324,7 +1433,7 @@ mod tests {
             None => panic!("Expected Some"),
         }
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 14);
@@ -1351,15 +1460,15 @@ mod tests {
         read_map.entry(14).unwrap().or_insert(28).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 12);
@@ -1368,7 +1477,7 @@ mod tests {
             None => panic!("Expected Some"),
         }
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 13);
@@ -1390,15 +1499,15 @@ mod tests {
         map.remove(12).unwrap();
 
         let map_iter = map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 13);
@@ -1423,15 +1532,15 @@ mod tests {
         read_map.remove(12).unwrap();
 
         let map_iter = read_map.children.range(..).peekable();
-        let store_iter = StoreNextIter::new(&store, ..).unwrap().peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
 
         let mut iter = Iter {
-            parent_store: &store,
+            parent: &read_map,
             map_iter,
             store_iter,
         };
 
-        let iter_next = Iter::iter_merge_next(&mut iter).unwrap();
+        let iter_next = Iter::iter_merge_next(&mut iter, true).unwrap();
         match iter_next {
             Some((key, value)) => {
                 assert_eq!(*key, 13);
@@ -1439,6 +1548,58 @@ mod tests {
             }
             None => panic!("Expected Some"),
         }
+    }
+
+    #[test]
+    fn iter_merge_next_rev() {
+        let (store, mut edit_map) = setup();
+
+        edit_map.entry(13).unwrap().or_insert(26).unwrap();
+        edit_map.entry(15).unwrap().or_insert(26).unwrap();
+        edit_map.entry(16).unwrap().or_insert(26).unwrap();
+        edit_map.entry(17).unwrap().or_insert(26).unwrap();
+
+        let mut buf = vec![];
+        edit_map.flush(&mut buf).unwrap();
+
+        let mut read_map: Map<u32, u32> = Map::with_store(store.clone()).unwrap();
+
+        read_map.insert(12, 28).unwrap();
+        read_map.insert(14, 28).unwrap();
+        read_map.insert(16, 28).unwrap();
+        read_map.entry(17).unwrap().remove().unwrap();
+
+        let map_iter = read_map.children.range(..).peekable();
+        let store_iter = StoreNextIter::new(&store, ..).unwrap();
+
+        let mut iter = Iter {
+            parent: &read_map,
+            map_iter,
+            store_iter,
+        };
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap().unwrap();
+        assert_eq!(*iter_next.0, 16);
+        assert_eq!(*iter_next.1, 28);
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap().unwrap();
+        assert_eq!(*iter_next.0, 15);
+        assert_eq!(*iter_next.1, 26);
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap().unwrap();
+        assert_eq!(*iter_next.0, 14);
+        assert_eq!(*iter_next.1, 28);
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap().unwrap();
+        assert_eq!(*iter_next.0, 13);
+        assert_eq!(*iter_next.1, 26);
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap().unwrap();
+        assert_eq!(*iter_next.0, 12);
+        assert_eq!(*iter_next.1, 28);
+
+        let iter_next = Iter::iter_merge_next(&mut iter, false).unwrap();
+        assert!(iter_next.is_none());
     }
 
     #[test]

--- a/src/merk/backingstore.rs
+++ b/src/merk/backingstore.rs
@@ -55,6 +55,20 @@ impl Read for BackingStore {
             BackingStore::Null(ref null) => null.get_next(key),
         }
     }
+
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        match self {
+            #[cfg(feature = "merk-full")]
+            BackingStore::WrappedMerk(ref store) => store.get_prev(key),
+            #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilder(ref builder) => builder.get_prev(key),
+            #[cfg(feature = "merk-full")]
+            BackingStore::Merk(ref store) => store.get_prev(key),
+            BackingStore::MapStore(ref store) => store.get_prev(key),
+            BackingStore::ProofMap(ref map) => map.get_prev(key),
+            BackingStore::Null(ref null) => null.get_prev(key),
+        }
+    }
 }
 
 impl Write for BackingStore {
@@ -173,6 +187,15 @@ impl Read for ProofStore {
     fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
         let mut iter = self.0.range((Bound::Excluded(key), Bound::Unbounded));
         let item = iter.next().transpose()?;
+        Ok(item.map(|(k, v)| (k.to_vec(), v.to_vec())))
+    }
+
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        let mut iter = self.0.range((
+            Bound::Unbounded,
+            key.map_or(Bound::Unbounded, |key| Bound::Excluded(key)),
+        ));
+        let item = iter.next_back().transpose()?;
         Ok(item.map(|(k, v)| (k.to_vec(), v.to_vec())))
     }
 }

--- a/src/merk/backingstore.rs
+++ b/src/merk/backingstore.rs
@@ -193,7 +193,7 @@ impl Read for ProofStore {
     fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
         let mut iter = self.0.range((
             Bound::Unbounded,
-            key.map_or(Bound::Unbounded, |key| Bound::Excluded(key)),
+            key.map_or(Bound::Unbounded, Bound::Excluded),
         ));
         let item = iter.next_back().transpose()?;
         Ok(item.map(|(k, v)| (k.to_vec(), v.to_vec())))

--- a/src/store/bufstore.rs
+++ b/src/store/bufstore.rs
@@ -166,7 +166,7 @@ where
             (true, false) => {
                 match map_iter.next().unwrap() {
                     // map value is not a delete, emit value
-                    (key, Some(value)) => Some((key.clone(), value.clone())),
+                    (key, Some(value)) => Some((key, value)),
                     // map value is a delete, go to next entry
                     (_, None) => continue,
                 }
@@ -199,7 +199,7 @@ where
 
                 // map key is before or at backing key, emit map entry (or skip if delete)
                 match map_iter.next().unwrap() {
-                    (key, Some(value)) => Some((key.clone(), value.clone())),
+                    (key, Some(value)) => Some((key, value)),
                     (_, None) => continue,
                 }
             }

--- a/src/store/bufstore.rs
+++ b/src/store/bufstore.rs
@@ -98,30 +98,59 @@ impl<S: Read> Read for BufStore<S> {
         }
     }
 
+    // TODO: optimize by retaining previously used iterator(s) so we don't
+    // have to recreate them each iteration (if it makes a difference)
+
     #[inline]
     fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
-        // TODO: optimize by retaining previously used iterator(s) so we don't
-        // have to recreate them each iteration (if it makes a difference)
-        let mut map_iter = self.map.range(exclusive_range_from(key));
-        let mut store_iter = (&self.store).into_iter(exclusive_range_from(key));
-        iter_merge_next(&mut map_iter, &mut store_iter)
+        let mut map_iter = self
+            .map
+            .range(exclusive_range_starting_from(key))
+            .map(|(k, v)| (k.clone(), v.clone()));
+        let mut store_iter = (&self.store).into_iter(exclusive_range_starting_from(key));
+        iter_merge_next(&mut map_iter, &mut store_iter, true)
+    }
+
+    #[inline]
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        let range = || {
+            key.map_or((Bound::Unbounded, Bound::Unbounded), |key| {
+                exclusive_range_ending_at(key)
+            })
+        };
+        let mut map_iter = self
+            .map
+            .range(range())
+            .rev()
+            .map(|(k, v)| (k.clone(), v.clone()));
+        let mut store_iter = (&self.store).into_iter(range()).rev();
+        iter_merge_next(&mut map_iter, &mut store_iter, false)
     }
 }
 
 /// Return range bounds which start from the given key (exclusive), with an
 /// unbounded end.
-fn exclusive_range_from(start: &[u8]) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+fn exclusive_range_starting_from(start: &[u8]) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     (Bound::Excluded(start.to_vec()), Bound::Unbounded)
+}
+
+fn exclusive_range_ending_at(start: &[u8]) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+    (Bound::Unbounded, Bound::Excluded(start.to_vec()))
 }
 
 /// Takes an iterator over entries in the in-memory map and an iterator over
 /// entries in the backing store, and yields the next entry. Entries in the map
 /// shadow entries in the backing store with the same key, including skipping
 /// entries marked as deleted (a `None` value in the map).
-fn iter_merge_next<S: Read>(
-    map_iter: &mut btree_map::Range<Vec<u8>, Option<Vec<u8>>>,
-    store_iter: &mut Iter<S>,
-) -> Result<Option<KV>> {
+fn iter_merge_next<M, S>(
+    map_iter: &mut M,
+    store_iter: &mut S,
+    increasing: bool,
+) -> Result<Option<KV>>
+where
+    M: Iterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
+    S: Iterator<Item = Result<KV>>,
+{
     let mut map_iter = map_iter.peekable();
     let mut store_iter = store_iter.peekable();
 
@@ -148,15 +177,17 @@ fn iter_merge_next<S: Read>(
 
             // merge values from both iterators
             (true, true) => {
-                let map_key = map_iter.peek().unwrap().0;
+                let map_key = &map_iter.peek().unwrap().0;
                 let backing_key = match store_iter.peek().unwrap() {
                     Err(_) => return Err(Error::Store("Backing key does not exist".into())),
                     Ok((ref key, _)) => key,
                 };
                 let key_cmp = map_key.cmp(backing_key);
 
-                // map key > backing key, emit backing entry
-                if key_cmp == Ordering::Greater {
+                // map key is past backing key, emit backing entry
+                if (increasing && key_cmp == Ordering::Greater)
+                    || (!increasing && key_cmp == Ordering::Less)
+                {
                     let entry = store_iter.next().unwrap()?;
                     return Ok(Some(entry));
                 }
@@ -166,7 +197,7 @@ fn iter_merge_next<S: Read>(
                     store_iter.next();
                 }
 
-                // map key <= backing key, emit map entry (or skip if delete)
+                // map key is before backing key, emit map entry (or skip if delete)
                 match map_iter.next().unwrap() {
                     (key, Some(value)) => Some((key.clone(), value.clone())),
                     (_, None) => continue,
@@ -233,6 +264,27 @@ mod tests {
         assert_eq!(iter.next().unwrap().unwrap(), (vec![1], vec![1]));
         assert_eq!(iter.next().unwrap().unwrap(), (vec![3], vec![1]));
         assert_eq!(iter.next().unwrap().unwrap(), (vec![4], vec![0]));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn rev_iter() {
+        let mut store = MapStore::new();
+        store.put(vec![0], vec![0]).unwrap();
+        store.put(vec![1], vec![0]).unwrap();
+        store.put(vec![2], vec![0]).unwrap();
+        store.put(vec![4], vec![0]).unwrap();
+
+        let mut buf = BufStore::wrap(store);
+        buf.put(vec![1], vec![1]).unwrap();
+        buf.delete(&[2]).unwrap();
+        buf.put(vec![3], vec![1]).unwrap();
+
+        let mut iter = buf.into_iter(..).rev();
+        assert_eq!(iter.next().unwrap().unwrap(), (vec![4], vec![0]));
+        assert_eq!(iter.next().unwrap().unwrap(), (vec![3], vec![1]));
+        assert_eq!(iter.next().unwrap().unwrap(), (vec![1], vec![1]));
+        assert_eq!(iter.next().unwrap().unwrap(), (vec![0], vec![0]));
         assert!(iter.next().is_none());
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -41,6 +41,18 @@ pub trait Read {
         }
     }
 
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>>;
+
+    fn get_prev_inclusive(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        match key {
+            Some(key) => match self.get(key)? {
+                Some(value) => Ok(Some((key.to_vec(), value))),
+                None => self.get_prev(Some(key)),
+            },
+            None => self.get_prev(None),
+        }
+    }
+
     /// Returns an iterator over the key/value entries in the given range.
     #[inline]
     fn into_iter<B: RangeBounds<Vec<u8>>>(self, bounds: B) -> Iter<Self>
@@ -75,6 +87,21 @@ impl<R: Read, T: Deref<Target = R>> Read for T {
     #[inline]
     fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
         self.deref().get_next(key)
+    }
+
+    #[inline]
+    fn get_next_inclusive(&self, key: &[u8]) -> Result<Option<KV>> {
+        self.deref().get_next_inclusive(key)
+    }
+
+    #[inline]
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        self.deref().get_prev(key)
+    }
+
+    #[inline]
+    fn get_prev_inclusive(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        self.deref().get_prev_inclusive(key)
     }
 }
 

--- a/src/store/nullstore.rs
+++ b/src/store/nullstore.rs
@@ -16,12 +16,18 @@ impl Read for NullStore {
     fn get_next(&self, _: &[u8]) -> Result<Option<KV>> {
         Ok(None)
     }
+
+    #[inline]
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        Ok(None)
+    }
 }
 
 impl Write for NullStore {
     fn put(&mut self, _key: Vec<u8>, _value: Vec<u8>) -> Result<()> {
         unimplemented!()
     }
+
     fn delete(&mut self, _key: &[u8]) -> Result<()> {
         unimplemented!()
     }
@@ -40,5 +46,11 @@ mod tests {
     fn get_next() {
         let store = NullStore;
         assert_eq!(store.get_next(&[1]).unwrap(), None)
+    }
+
+    #[test]
+    fn get_prev() {
+        let store = NullStore;
+        assert_eq!(store.get_prev(Some(&[1])).unwrap(), None)
     }
 }

--- a/src/store/nullstore.rs
+++ b/src/store/nullstore.rs
@@ -18,7 +18,7 @@ impl Read for NullStore {
     }
 
     #[inline]
-    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+    fn get_prev(&self, _key: Option<&[u8]>) -> Result<Option<KV>> {
         Ok(None)
     }
 }

--- a/src/store/share.rs
+++ b/src/store/share.rs
@@ -59,6 +59,11 @@ impl<T: Read> Read for Shared<T> {
     fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
         self.0.borrow().get_next(key)
     }
+
+    #[inline]
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
+        self.0.borrow().get_prev(key)
+    }
 }
 
 impl<W: Write> Write for Shared<W> {

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -168,8 +168,6 @@ impl<S: Read> Read for Store<S> {
             let prefixed = concat(self.prefix.as_slice(), key);
             self.store
                 .get_prev(Some(prefixed.as_slice()))?
-                // TODO: terminating with filter is wrong, this will read all
-                // keys in store after reaching end
                 .filter(|(k, _)| k.starts_with(self.prefix.as_slice()))
                 .map(|(k, v)| (k[self.prefix.len()..].into(), v))
         } else {
@@ -281,7 +279,7 @@ mod test {
         let mut backing = MapStore::new();
         backing.put(vec![0, 0], vec![0]).unwrap();
 
-        let mut store = Store::new(&mut backing);
+        let store = Store::new(&mut backing);
         assert_eq!(
             store.get_prev(None).unwrap().unwrap(),
             (vec![0, 0], vec![0])

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -275,4 +275,16 @@ mod test {
         assert!(backing.get(&[1, 3, 1]).unwrap().is_none());
         assert_eq!(backing.get(&[1, 3, 2]).unwrap().unwrap(), vec![5, 0]);
     }
+
+    #[test]
+    fn get_prev_empty_key() {
+        let mut backing = MapStore::new();
+        backing.put(vec![0, 0], vec![0]).unwrap();
+
+        let mut store = Store::new(&mut backing);
+        assert_eq!(
+            store.get_prev(None).unwrap().unwrap(),
+            (vec![0, 0], vec![0])
+        );
+    }
 }

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -173,9 +173,14 @@ impl<S: Read> Read for Store<S> {
                 .filter(|(k, _)| k.starts_with(self.prefix.as_slice()))
                 .map(|(k, v)| (k[self.prefix.len()..].into(), v))
         } else {
-            let end_key = increment_bytes(self.prefix.clone());
+            let incremented = increment_bytes(self.prefix.clone());
+            let end_key = if !self.prefix.is_empty() {
+                Some(incremented.as_slice())
+            } else {
+                None
+            };
             self.store
-                .get_prev(Some(end_key.as_slice()))?
+                .get_prev(end_key)?
                 .filter(|(k, _)| k.starts_with(self.prefix.as_slice()))
                 .map(|(k, v)| (k[self.prefix.len()..].into(), v))
         };


### PR DESCRIPTION
This PR adds reverse iteration, concretely by adding:

- a `get_prev` method in the store `Read` trait to complement `get_next`, and implementations for all built-in stores, including `MerkStore`
- implementations for `DoubleEndedIterator` for the various iterators (the iterators for `Map`, `Deque`, `store::Read`, `Store`, `BufStore`, etc.).
- an upgrade of Merk to include `DoubleEndedIterator` for raw store iterators, and for proof `Map`s.