### PR TITLE
Upgrade signalling version format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ abci2 = { git = "https://github.com/nomic-io/abci2", rev = "cba210e7ac6c9006d81c
 tendermint-rpc = { version = "=0.30.0", features = ["http-client"], optional = true }
 tendermint = { version = "=0.30.0", optional = true }
 tendermint-proto = { version = "=0.30.0" }
-merk = { git = "https://github.com/nomic-io/merk", rev = "cf2fe85e735d6ac908b53ca0dc8ff5f50ef721e8", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "aaa870e603b0cbe8437aee5c9538926ed078a082", optional = true, default-features = false }
 orga-macros = { path = "macros", version = "0.3.1" }
 seq-macro = "0.3.3"
 log = "0.4.17"

--- a/src/ibc/mod.rs
+++ b/src/ibc/mod.rs
@@ -59,7 +59,11 @@ pub const IBC_QUERY_PATH: &str = "store/ibc/key";
 #[orga(version = 1)]
 pub struct Ibc {
     #[orga(version(V0))]
-    _bytes: [u64; 10],
+    _bytes0: [u8; 32],
+    #[orga(version(V0))]
+    _bytes1: [u8; 32],
+    #[orga(version(V0))]
+    _bytes2: [u8; 23],
 
     #[orga(version(V0))]
     #[state(prefix(b""))]

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -38,8 +38,35 @@ impl MerkStore {
         // TODO: return result instead of panicking
         maybe_remove_restore(&home).expect("Failed to remove incomplete state sync restore");
 
-        let snapshot_path = home.join("snapshots");
-        let snapshots = snapshot::Snapshots::load(snapshot_path.as_path())
+        MerkStore {
+            map: Some(Default::default()),
+            merk: Some(merk),
+            snapshots: Self::load_snapshots(home.join("snapshots")),
+            home,
+            target_snapshot: None,
+            restorer: None,
+        }
+    }
+
+    pub fn open_readonly<P: AsRef<Path>>(home: P) -> Self {
+        let home = home.as_ref().to_path_buf();
+        let merk = Merk::open_readonly(home.join("db")).unwrap();
+
+        // TODO: populate snapshots, if we can do it safely concurrently with
+        // other processes
+
+        MerkStore {
+            map: Some(Default::default()),
+            merk: Some(merk),
+            snapshots: Self::load_snapshots(home.join("snapshots")),
+            home,
+            target_snapshot: None,
+            restorer: None,
+        }
+    }
+
+    fn load_snapshots<P: AsRef<Path>>(path: P) -> snapshot::Snapshots {
+        snapshot::Snapshots::load(path.as_ref())
             .expect("Failed to load snapshots")
             // TODO: make configurable
             .with_filters(vec![
@@ -48,16 +75,7 @@ impl MerkStore {
                 #[cfg(feature = "state-sync")]
                 snapshot::SnapshotFilter::interval(1000, 4),
                 snapshot::SnapshotFilter::interval(1, 20),
-            ]);
-
-        MerkStore {
-            map: Some(Default::default()),
-            merk: Some(merk),
-            home,
-            snapshots,
-            target_snapshot: None,
-            restorer: None,
-        }
+            ])
     }
 
     pub fn init_from(

--- a/src/plugins/chain_commitment.rs
+++ b/src/plugins/chain_commitment.rs
@@ -8,7 +8,6 @@ use crate::encoding::LengthVec;
 use crate::encoding::{Decode, Encode};
 
 use crate::migrate::{MigrateFrom, MigrateInto};
-use crate::state::State;
 use crate::{Error, Result};
 use std::ops::Deref;
 
@@ -115,6 +114,7 @@ mod abci {
     use super::super::{BeginBlockCtx, EndBlockCtx, InitChainCtx};
     use super::*;
     use crate::abci::{BeginBlock, EndBlock, InitChain};
+    use crate::state::State;
 
     impl<T> BeginBlock for ChainCommitmentPlugin<T>
     where

--- a/src/plugins/query.rs
+++ b/src/plugins/query.rs
@@ -101,6 +101,8 @@ impl<T: State + Describe> Describe for QueryPlugin<T> {
 // TODO: Remove dependency on ABCI for this otherwise-pure plugin.
 #[cfg(feature = "abci")]
 mod abci {
+    use std::ops::DerefMut;
+
     use super::super::{BeginBlockCtx, EndBlockCtx, InitChainCtx};
     use super::*;
     use crate::abci::{BeginBlock, EndBlock, InitChain};
@@ -111,7 +113,7 @@ mod abci {
         T: BeginBlock + State,
     {
         fn begin_block(&mut self, ctx: &BeginBlockCtx) -> Result<()> {
-            self.inner.borrow_mut().begin_block(ctx)
+            self.inner.borrow_mut().deref_mut().begin_block(ctx)
         }
     }
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -39,7 +39,7 @@ pub struct Upgrade {
     pub current_version: Version,
     #[orga(version(V1))]
     #[state(absolute_prefix(b"/version"))]
-    // TODO: use Value/Box instead of Map<(), T>
+    // TODO: use Value/Box instead of Map<(), _>
     pub current_version: Map<(), Version>,
 }
 
@@ -62,7 +62,7 @@ impl Default for Upgrade {
 impl MigrateFrom<UpgradeV0> for UpgradeV1 {
     fn migrate_from(other: UpgradeV0) -> Result<Self> {
         let mut current_version = Map::new();
-        current_version.insert((), other.current_version).unwrap();
+        current_version.insert((), other.current_version)?;
         Ok(Self {
             signals: other.signals.migrate_into()?,
             threshold: other.threshold,

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -2,11 +2,15 @@ use crate::coins::{Address, Amount, Decimal};
 use crate::collections::Map;
 use crate::context::GetContext;
 use crate::encoding::LengthVec;
+use crate::migrate::{MigrateFrom, MigrateInto};
 use crate::orga;
 use crate::plugins::{Signer, Time, ValidatorEntry, Validators};
+use crate::prelude::{Read, Store};
 use crate::{Error as OrgaError, Result};
 use std::collections::HashMap;
 use thiserror::Error;
+
+pub const VERSION_KEY: &[u8] = b"/version";
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -25,24 +29,49 @@ pub struct Signal {
     pub time: i64,
 }
 
-#[orga(skip(Default))]
+#[orga(skip(Default), version = 1)]
 pub struct Upgrade {
     signals: Map<PubKey, Signal>,
     pub threshold: Decimal,
     pub activation_delay_seconds: i64,
     pub rate_limit_seconds: i64,
+    #[orga(version(V0))]
     pub current_version: Version,
+    #[orga(version(V1))]
+    #[state(absolute_prefix(b"/version"))]
+    // TODO: use Value/Box instead of Map<(), T>
+    pub current_version: Map<(), Version>,
 }
 
 impl Default for Upgrade {
     fn default() -> Self {
+        let mut current_version = Map::new();
+        current_version
+            .insert((), vec![0].try_into().unwrap())
+            .unwrap();
         Self {
             signals: Default::default(),
             threshold: (Amount::new(2) / Amount::new(3)).result().unwrap(),
             activation_delay_seconds: 60 * 60 * 24,
             rate_limit_seconds: 60,
-            current_version: vec![0].try_into().unwrap(),
+            current_version,
         }
+    }
+}
+
+impl MigrateFrom<UpgradeV0> for UpgradeV1 {
+    fn migrate_from(other: UpgradeV0) -> Result<Self> {
+        let mut current_version = Map::new();
+        current_version
+            .insert((), other.current_version.into())
+            .unwrap();
+        Ok(Self {
+            signals: other.signals.migrate_into()?,
+            threshold: other.threshold,
+            activation_delay_seconds: other.activation_delay_seconds,
+            rate_limit_seconds: other.rate_limit_seconds,
+            current_version,
+        })
     }
 }
 
@@ -74,17 +103,24 @@ impl Upgrade {
         self.signals.insert(cons_key, signal)
     }
 
-    pub fn step(&mut self, version: &Version) -> Result<()> {
-        let version = version.clone();
-        if self.current_version != version {
+    pub fn step(&mut self, bin_version: &Version) -> Result<()> {
+        let bin_version = bin_version.clone();
+        let net_version = self
+            .current_version
+            .get(())?
+            .unwrap()
+            .clone()
+            .try_into()
+            .unwrap();
+        if bin_version != net_version {
             return Err(Error::Version {
-                expected: self.current_version.clone(),
-                actual: version,
+                expected: net_version.clone(),
+                actual: bin_version,
             }
             .into());
         }
         if let Some(new_version) = self.upgrade_ready()? {
-            self.current_version = new_version;
+            self.current_version.insert((), new_version.into())?;
         }
         Ok(())
     }
@@ -98,7 +134,9 @@ impl Upgrade {
             total_vp += validator.power;
             if let Some(signal) = self.signals.get(validator.pubkey)? {
                 if signal.time <= latest_counted_time
-                    && signal.version != self.current_version
+                    // TODO: implement comparison between LengthVec and Vec
+                    && signal.version.clone()
+                        != *self.current_version.get(())?.unwrap()
                     && validator.power > 0
                 {
                     *signal_vps.entry(signal.version.clone()).or_default() += validator.power;
@@ -147,6 +185,11 @@ impl Upgrade {
     }
 }
 
+pub fn load_version(store: Store) -> Result<Option<Vec<u8>>> {
+    let store = unsafe { store.with_prefix(vec![]) };
+    store.get(VERSION_KEY)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,13 +236,13 @@ mod tests {
         let mut upgrade = Upgrade {
             activation_delay_seconds: 10,
             rate_limit_seconds: 5,
-            current_version: version.clone(),
             ..Default::default()
         };
+        upgrade.current_version.insert((), version.clone())?;
 
         assert!(upgrade.upgrade_ready()?.is_none());
         upgrade.step(&version)?;
-        assert_eq!(upgrade.current_version, version);
+        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
         set_signer([0; 20]);
         upgrade.signal(next_version.clone())?;
         set_time(1);
@@ -209,12 +252,12 @@ mod tests {
         assert!(upgrade.upgrade_ready()?.is_none());
         upgrade.step(&version)?;
         assert!(upgrade.step(&next_version).is_err());
-        assert_eq!(upgrade.current_version, version);
+        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
         set_time(12);
         assert!(upgrade.upgrade_ready()?.unwrap() == next_version);
-        assert_eq!(upgrade.current_version, version);
+        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
         upgrade.step(&version)?;
-        assert_eq!(upgrade.current_version, next_version);
+        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
         assert!(upgrade.step(&version).is_err());
         upgrade.step(&next_version)?;
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -62,9 +62,7 @@ impl Default for Upgrade {
 impl MigrateFrom<UpgradeV0> for UpgradeV1 {
     fn migrate_from(other: UpgradeV0) -> Result<Self> {
         let mut current_version = Map::new();
-        current_version
-            .insert((), other.current_version.into())
-            .unwrap();
+        current_version.insert((), other.current_version).unwrap();
         Ok(Self {
             signals: other.signals.migrate_into()?,
             threshold: other.threshold,
@@ -105,22 +103,16 @@ impl Upgrade {
 
     pub fn step(&mut self, bin_version: &Version) -> Result<()> {
         let bin_version = bin_version.clone();
-        let net_version = self
-            .current_version
-            .get(())?
-            .unwrap()
-            .clone()
-            .try_into()
-            .unwrap();
+        let net_version = self.current_version.get(())?.unwrap().clone();
         if bin_version != net_version {
             return Err(Error::Version {
-                expected: net_version.clone(),
+                expected: net_version,
                 actual: bin_version,
             }
             .into());
         }
         if let Some(new_version) = self.upgrade_ready()? {
-            self.current_version.insert((), new_version.into())?;
+            self.current_version.insert((), new_version)?;
         }
         Ok(())
     }
@@ -257,7 +249,7 @@ mod tests {
         assert!(upgrade.upgrade_ready()?.unwrap() == next_version);
         assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
         upgrade.step(&version)?;
-        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &version);
+        assert_eq!(&*upgrade.current_version.get(())?.unwrap(), &next_version);
         assert!(upgrade.step(&version).is_err());
         upgrade.step(&next_version)?;
 


### PR DESCRIPTION
This PR moves the upgrade signalling version to an absolute key path, so that it can be relied on in the future from states with unknown state formats.

There are also other important fixes included, e.g. fixing IBC V0 state compatibility.