### PR TITLE
Async client fixes

### DIFF
--- a/macros/src/field_call.rs
+++ b/macros/src/field_call.rs
@@ -399,7 +399,7 @@ impl ToTokens for FieldCallEnum {
 
         tokens.extend(quote! {
             #vis enum #ident #imp #wher {
-                Noop(::std::marker::PhantomData<#unused_generics>),
+                Noop(::std::marker::PhantomData<fn(#unused_generics)>),
                 #(#variants),*
             }
 

--- a/macros/src/field_query.rs
+++ b/macros/src/field_query.rs
@@ -355,7 +355,7 @@ impl ToTokens for FieldQueryEnum {
             #[derive(::orga::Educe)]
             #[educe(Debug)]
             #vis enum #ident #imp #wher {
-                Noop(::std::marker::PhantomData<#unused_generics>),
+                Noop(::std::marker::PhantomData<fn(#unused_generics)>),
                 #(#variants),*
             }
 

--- a/macros/src/method_call.rs
+++ b/macros/src/method_call.rs
@@ -85,7 +85,7 @@ fn method_call_enum(tokens: &mut TokenStream2, item: &ItemImpl) {
             quote! { #ident }
         })
         .collect_vec();
-    variants.push(quote! { Noop(::std::marker::PhantomData<(#( #tp ),*)>) });
+    variants.push(quote! { Noop(::std::marker::PhantomData<fn((#( #tp ),*))>) });
 
     let enum_debug = {
         let child_debugs = call_methods(&item).into_iter().map(|field| {

--- a/macros/src/method_query.rs
+++ b/macros/src/method_query.rs
@@ -92,7 +92,7 @@ fn method_query_enum(tokens: &mut TokenStream2, item: &ItemImpl) {
             quote! { #ident }
         })
         .collect_vec();
-    variants.push(quote! { Noop(::std::marker::PhantomData<(#( #tp ),*)>) });
+    variants.push(quote! { Noop(::std::marker::PhantomData<fn((#( #tp ),*))>) });
 
     let _enum_debug = {
         let child_debugs = query_methods(&item).into_iter().map(|field| {

--- a/src/call.rs
+++ b/src/call.rs
@@ -10,7 +10,7 @@ pub use orga_macros::{build_call, call_block, FieldCall};
 pub const PREFIX_OFFSET: u8 = 0x40;
 
 pub trait Call {
-    type Call: Encode + Decode + std::fmt::Debug;
+    type Call: Encode + Decode + std::fmt::Debug + Send + Sync;
 
     fn call(&mut self, call: Self::Call) -> Result<()>;
 }
@@ -285,13 +285,13 @@ impl<T: Decode + std::fmt::Debug, U: Decode + std::fmt::Debug> Decode for Item<T
 }
 
 pub trait FieldCall {
-    type FieldCall: Encode + Decode + std::fmt::Debug = ();
+    type FieldCall: Encode + Decode + std::fmt::Debug + Send + Sync = ();
 
     fn field_call(&mut self, call: Self::FieldCall) -> Result<()>;
 }
 
 pub trait MethodCall {
-    type MethodCall: Encode + Decode + std::fmt::Debug = ();
+    type MethodCall: Encode + Decode + std::fmt::Debug + Send + Sync = ();
 
     fn method_call(&mut self, call: Self::MethodCall) -> Result<()>;
 }
@@ -327,7 +327,7 @@ pub trait BuildCall<const ID: &'static str>: Call + Sized {
 }
 
 pub struct CallBuilder<T> {
-    _phantom: std::marker::PhantomData<T>,
+    _phantom: std::marker::PhantomData<fn(T)>,
 }
 
 impl<T> CallBuilder<T> {

--- a/src/client/exec.rs
+++ b/src/client/exec.rs
@@ -49,6 +49,8 @@ pub async fn execute<T, U>(
 ) -> Result<(U, Store)>
 where
     T: App + State + Query + Call + Describe,
+    T::Query: Send + Sync,
+    T::Call: Send + Sync,
 {
     let mut store = store;
     let mut last_n = None;

--- a/src/client/mock.rs
+++ b/src/client/mock.rs
@@ -21,7 +21,7 @@ pub struct MockClient<T> {
     pub queries: RefCell<Vec<Vec<u8>>>,
     pub calls: RefCell<Vec<Vec<u8>>>,
     pub store: Store,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<fn(T)>,
 }
 
 impl<T> MockClient<T> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,6 @@ use crate::store::Store;
 
 use crate::Result;
 
-use std::cell::Cell;
 use std::marker::PhantomData;
 
 pub mod exec;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,9 +37,6 @@ pub struct AppClient<T, U, Transport, Symbol, Wallet> {
     _pd: PhantomData<Symbol>,
     transport: Transport,
     wallet: Wallet,
-    // TODO: don't keep store here, and let something in the Transport layer
-    // handle persistence/joining/etc for composibility
-    store: Cell<Option<Store>>,
     sub: fn(T) -> U,
 }
 
@@ -87,6 +84,39 @@ pub mod sync {
 
 use crate::plugins::DefaultPlugins;
 
+impl<T, U, Transport, Symbol, Wallet> AppClient<T, U, Transport, Symbol, Wallet> {
+    pub fn new(client: Transport, wallet: Wallet) -> Self
+    where
+        T: Into<U>,
+    {
+        Self {
+            _pd: PhantomData,
+            transport: client,
+            wallet,
+            sub: Into::into,
+        }
+    }
+
+    pub fn with_wallet<W2>(self, wallet: W2) -> AppClient<T, U, Transport, Symbol, W2> {
+        AppClient {
+            _pd: PhantomData,
+            transport: self.transport,
+            wallet,
+            sub: self.sub,
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn sub<U2>(self, sub: fn(T) -> U2) -> AppClient<T, U2, Transport, Symbol, Wallet> {
+        AppClient {
+            _pd: PhantomData,
+            transport: self.transport,
+            wallet: self.wallet,
+            sub,
+        }
+    }
+}
+
 impl<T, U, Transport, Symbol, Wallet> AppClient<T, U, Transport, Symbol, Wallet>
 where
     Transport: exec::Transport<ABCIPlugin<DefaultPlugins<Symbol, T>>>,
@@ -101,43 +131,6 @@ where
     Wallet: wallet::Wallet + Clone,
     Symbol: crate::coins::Symbol,
 {
-    pub fn new(client: Transport, wallet: Wallet) -> Self
-    where
-        T: Into<U>,
-    {
-        Self {
-            _pd: PhantomData,
-            transport: client,
-            wallet,
-            store: Cell::new(None),
-            sub: Into::into,
-        }
-    }
-
-    pub fn with_wallet<W2: wallet::Wallet>(
-        self,
-        wallet: W2,
-    ) -> AppClient<T, U, Transport, Symbol, W2> {
-        AppClient {
-            _pd: PhantomData,
-            transport: self.transport,
-            wallet,
-            store: self.store,
-            sub: self.sub,
-        }
-    }
-
-    #[allow(clippy::should_implement_trait)]
-    pub fn sub<U2>(self, sub: fn(T) -> U2) -> AppClient<T, U2, Transport, Symbol, Wallet> {
-        AppClient {
-            _pd: PhantomData,
-            transport: self.transport,
-            wallet: self.wallet,
-            store: self.store,
-            sub,
-        }
-    }
-
     // TODO: support subclients
     // TODO: return object with result data (e.g. txid)
     pub async fn call(
@@ -145,18 +138,23 @@ where
         payer: impl FnOnce(&U) -> T::Call,
         payee: impl FnOnce(&U) -> T::Call,
     ) -> Result<()> {
-        let chain_id = self
-            .query_root(|app| Ok(app.inner.inner.borrow().inner.inner.chain_id.to_vec()))
-            .await?;
-        let nonce = match self.wallet.address()? {
-            None => None,
-            Some(addr) => Some(
-                self.query_root(|app| app.inner.inner.borrow_mut().inner.inner.inner.nonce(addr))
-                    .await?
-                    + 1,
-            ),
+        let (chain_id, store) = exec::execute(Store::default(), &self.transport, |app| {
+            Ok(app.inner.inner.borrow().inner.inner.chain_id.to_vec())
+        })
+        .await?;
+        let (nonce, store) = match self.wallet.address()? {
+            None => (None, store),
+            Some(addr) => {
+                exec::execute(store, &self.transport, |app| {
+                    Ok(Some(
+                        app.inner.inner.borrow_mut().inner.inner.inner.nonce(addr)? + 1,
+                    ))
+                })
+                .await?
+            }
         };
-        let app = self.query(Ok).await?;
+
+        let app = self.query_with_store(store, Ok).await?;
 
         let payer_call = payer(&app);
         let payer_call_bytes = payer_call.encode()?;
@@ -180,19 +178,20 @@ where
         &self,
         op: F2,
     ) -> Result<U2> {
-        let store = self.store.take().unwrap_or_default();
-
-        let (res, store) = exec::execute(store, &self.transport, op).await?;
-
-        self.store.replace(Some(store));
-
+        let (res, _) = exec::execute(Store::default(), &self.transport, op).await?;
         Ok(res)
     }
 
-    pub async fn query<U2, F2: FnMut(U) -> Result<U2>>(&self, mut op: F2) -> Result<U2> {
-        let store = self.store.take().unwrap_or_default();
+    pub async fn query<U2, F2: FnMut(U) -> Result<U2>>(&self, op: F2) -> Result<U2> {
+        self.query_with_store(Store::default(), op).await
+    }
 
-        let (res, store) = exec::execute(store, &self.transport, |app| {
+    async fn query_with_store<U2, F2: FnMut(U) -> Result<U2>>(
+        &self,
+        store: Store,
+        mut op: F2,
+    ) -> Result<U2> {
+        let (res, _) = exec::execute(store, &self.transport, |app| {
             let inner = app
                 .inner
                 .inner
@@ -206,9 +205,6 @@ where
             op((self.sub)(inner))
         })
         .await?;
-
-        self.store.replace(Some(store));
-
         Ok(res)
     }
 }
@@ -234,17 +230,19 @@ where
         payer: impl FnOnce(&U) -> T::Call,
         payee: impl FnOnce(&U) -> T::Call,
     ) -> Result<()> {
-        let chain_id =
-            self.query_root_sync(|app| Ok(app.inner.inner.borrow().inner.inner.chain_id.to_vec()))?;
-        let nonce = match self.wallet.address()? {
-            None => None,
-            Some(addr) => Some(
-                self.query_root_sync(|app| {
-                    app.inner.inner.borrow_mut().inner.inner.inner.nonce(addr)
-                })? + 1,
-            ),
+        let (chain_id, store) = exec::sync::execute(Store::default(), &self.transport, |app| {
+            Ok(app.inner.inner.borrow().inner.inner.chain_id.to_vec())
+        })?;
+        let (nonce, store) = match self.wallet.address()? {
+            None => (None, store),
+            Some(addr) => exec::sync::execute(store, &self.transport, |app| {
+                Ok(Some(
+                    app.inner.inner.borrow_mut().inner.inner.inner.nonce(addr)? + 1,
+                ))
+            })?,
         };
-        let app = self.query_sync(Ok)?;
+
+        let app = self.query_with_store_sync(store, Ok)?;
 
         let payer_call = payer(&app);
         let payer_call_bytes = payer_call.encode()?;
@@ -259,7 +257,7 @@ where
         let call = [chain_id, call.encode()?].concat();
         let call = self.wallet.sign(&call)?;
         let call = ABCICall::DeliverTx(sdk_compat::Call::Native(call));
-        exec::sync::Transport::call_sync(&self.transport, call)?;
+        self.transport.call_sync(call)?;
 
         Ok(())
     }
@@ -268,19 +266,20 @@ where
         &self,
         op: F2,
     ) -> Result<U2> {
-        let store = self.store.take().unwrap_or_default();
-
-        let (res, store) = exec::sync::execute(store, &self.transport, op)?;
-
-        self.store.replace(Some(store));
-
+        let (res, _) = exec::sync::execute(Store::default(), &self.transport, op)?;
         Ok(res)
     }
 
-    pub fn query_sync<U2, F2: FnMut(U) -> Result<U2>>(&self, mut op: F2) -> Result<U2> {
-        let store = self.store.take().unwrap_or_default();
+    pub fn query_sync<U2, F2: FnMut(U) -> Result<U2>>(&self, op: F2) -> Result<U2> {
+        self.query_with_store_sync(Store::default(), op)
+    }
 
-        let (res, store) = exec::sync::execute(store, &self.transport, |app| {
+    pub fn query_with_store_sync<U2, F2: FnMut(U) -> Result<U2>>(
+        &self,
+        store: Store,
+        mut op: F2,
+    ) -> Result<U2> {
+        let (res, _) = exec::sync::execute(store, &self.transport, |app| {
             let inner = app
                 .inner
                 .inner
@@ -293,9 +292,6 @@ where
                 .inner;
             op((self.sub)(inner))
         })?;
-
-        self.store.replace(Some(store));
-
         Ok(res)
     }
 }

--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -14,7 +14,7 @@ use std::ops::{Deref, DerefMut, Drop, RangeBounds};
 #[orga]
 pub struct Pool<K, V, S>
 where
-    K: Terminated + Encode + Decode + Clone + 'static,
+    K: Terminated + Encode + Decode + Clone + Send + Sync + 'static,
     V: State,
     S: Symbol,
 {
@@ -31,7 +31,7 @@ where
 
 impl<K, V, S> Balance<S, Decimal> for Pool<K, V, S>
 where
-    K: Terminated + Encode + Decode + Clone + 'static,
+    K: Terminated + Encode + Decode + Clone + Send + Sync + 'static,
     V: State,
     S: Symbol,
 {
@@ -66,7 +66,7 @@ impl<T: State> DerefMut for Entry<T> {
 
 impl<K, V, S> Pool<K, V, S>
 where
-    K: Terminated + Encode + Decode + Clone + 'static,
+    K: Terminated + Encode + Decode + Clone + Send + Sync + 'static,
     V: State,
     S: Symbol,
 {
@@ -80,7 +80,7 @@ where
 
 impl<K, V, S> Pool<K, V, S>
 where
-    K: Encode + Decode + Terminated + Clone + 'static,
+    K: Encode + Decode + Terminated + Clone + Send + Sync + 'static,
     V: State + Balance<S, Decimal> + Give<(u8, Amount)> + Default,
     S: Symbol,
 {
@@ -208,7 +208,7 @@ pub type IterEntry<'a, K, V, S> = Result<(K, Child<'a, V, S>)>;
 impl<K, V, S> Pool<K, V, S>
 where
     S: Symbol,
-    K: Encode + Decode + Terminated + Clone + Next + 'static,
+    K: Encode + Decode + Terminated + Clone + Next + Send + Sync + 'static,
     V: State + Balance<S, Decimal> + Give<(u8, Amount)> + Default,
 {
     pub fn range<B>(&self, bounds: B) -> Result<impl Iterator<Item = IterEntry<K, V, S>>>
@@ -232,7 +232,7 @@ impl<K, V, S, T> Give<Coin<T>> for Pool<K, V, S>
 where
     S: Symbol,
     T: Symbol,
-    K: Encode + Terminated + Decode + Clone + 'static,
+    K: Encode + Terminated + Decode + Clone + Send + Sync + 'static,
     V: State,
 {
     fn give(&mut self, coin: Coin<T>) -> Result<()> {
@@ -250,7 +250,7 @@ where
 impl<K, V, S> Give<(u8, Amount)> for Pool<K, V, S>
 where
     S: Symbol,
-    K: Encode + Terminated + Decode + Clone + 'static,
+    K: Encode + Terminated + Decode + Clone + Send + Sync + 'static,
     V: State,
 {
     fn give(&mut self, coin: (u8, Amount)) -> Result<()> {

--- a/src/coins/symbol.rs
+++ b/src/coins/symbol.rs
@@ -2,7 +2,7 @@ use super::{Amount, Coin};
 use crate::{migrate::MigrateFrom, state::State};
 
 pub trait Symbol:
-    Sized + State + std::fmt::Debug + 'static + Clone + Send + Default + MigrateFrom
+    Sized + State + std::fmt::Debug + 'static + Clone + Send + Default + MigrateFrom + Send + Sync
 {
     const INDEX: u8;
     fn mint<I: Into<Amount>>(amount: I) -> Coin<Self> {

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -147,7 +147,7 @@ impl<K, V> Default for Map<K, V> {
 #[orga]
 impl<K, V> Map<K, V>
 where
-    K: Encode + Terminated + 'static,
+    K: Encode + Terminated + Send + Sync + 'static,
     V: State,
 {
     #[query]
@@ -242,9 +242,9 @@ where
 
 impl<K1, V1, K2, V2> MigrateFrom<Map<K1, V1>> for Map<K2, V2>
 where
-    K1: MigrateInto<K2> + Encode + Decode + Terminated + Clone + 'static,
+    K1: MigrateInto<K2> + Encode + Decode + Terminated + Clone + Send + Sync + 'static,
     V1: MigrateInto<V2> + State,
-    K2: Encode + Decode + Terminated + Clone + 'static,
+    K2: Encode + Decode + Terminated + Clone + Send + Sync + 'static,
     V2: State,
 {
     fn migrate_from(mut other: Map<K1, V1>) -> Result<Self> {
@@ -271,7 +271,7 @@ where
 
 impl<K, V> Map<K, V>
 where
-    K: Encode + Terminated + 'static,
+    K: Encode + Terminated + Send + Sync + 'static,
     V: State + Default,
 {
     pub fn get_or_default(&self, key: K) -> Result<Ref<V>> {
@@ -311,7 +311,7 @@ where
 #[orga]
 impl<K, V> Map<K, V>
 where
-    K: Encode + Terminated + Clone + 'static,
+    K: Encode + Terminated + Clone + Send + Sync + 'static,
     V: State,
 {
     /// Gets a mutable reference to the value in the map for the given key, or
@@ -893,7 +893,7 @@ pub enum ChildMut<'a, K, V> {
 
 impl<'a, K, V> ChildMut<'a, K, V>
 where
-    K: Encode + Terminated + Clone + 'static,
+    K: Encode + Terminated + Clone + Send + Sync + 'static,
     V: State,
 {
     /// Removes the value and all of its child key/value entries (if any) from
@@ -1022,7 +1022,7 @@ impl<K: Encode + Decode + Terminated + 'static, V: State> Map<K, V> {
 
 impl<'a, K, V> Entry<'a, K, V>
 where
-    K: Encode + Terminated + Clone + 'static,
+    K: Encode + Terminated + Clone + Send + Sync + 'static,
     V: State,
 {
     /// Removes the value for the `Entry` if it exists. Returns a boolean which

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -19,10 +19,10 @@ pub use map::{ChildMut, Ref};
 /// singular structs while storing them in a map as a key/value pair.
 pub trait Entry: 'static {
     /// Represents the key type for the key/value pair.
-    type Key: Encode + Decode;
+    type Key: Encode + Decode + Send + Sync;
 
     /// Represents the value type for the key/value pair.
-    type Value: State;
+    type Value: State + Send + Sync;
 
     /// Converts the entry type into its corresponding key and value types.
     fn into_entry(self) -> (Self::Key, Self::Value);

--- a/src/describe/child.rs
+++ b/src/describe/child.rs
@@ -3,4 +3,4 @@ pub trait Child {
     type Child;
 }
 
-pub struct Field<T, const ID: u128>(std::marker::PhantomData<T>);
+pub struct Field<T, const ID: u128>(std::marker::PhantomData<fn(T)>);

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ pub use orga_macros::{query_block, FieldQuery};
 
 pub const PREFIX_OFFSET: u8 = 0x80;
 pub trait Query {
-    type Query: Encode + Decode + std::fmt::Debug;
+    type Query: Encode + Decode + std::fmt::Debug + Send + Sync;
 
     fn query(&self, query: Self::Query) -> Result<()>;
 }
@@ -243,13 +243,13 @@ impl<T: Decode + std::fmt::Debug, U: Decode + std::fmt::Debug> Decode for Item<T
     }
 }
 pub trait FieldQuery {
-    type FieldQuery: Encode + Decode + std::fmt::Debug = ();
+    type FieldQuery: Encode + Decode + std::fmt::Debug + Send + Sync = ();
 
     fn field_query(&self, query: Self::FieldQuery) -> Result<()>;
 }
 
 pub trait MethodQuery {
-    type MethodQuery: Encode + Decode + std::fmt::Debug = ();
+    type MethodQuery: Encode + Decode + std::fmt::Debug + Send + Sync = ();
 
     fn method_query(&self, query: Self::MethodQuery) -> Result<()>;
 }

--- a/src/store/share.rs
+++ b/src/store/share.rs
@@ -1,7 +1,5 @@
 use super::{Read, Write, KV};
 use crate::Result;
-use std::cell::{Ref, RefCell, RefMut};
-use std::rc::Rc;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 // TODO: we can probably use UnsafeCell instead of RefCell since operations are

--- a/src/store/share.rs
+++ b/src/store/share.rs
@@ -2,6 +2,7 @@ use super::{Read, Write, KV};
 use crate::Result;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 // TODO: we can probably use UnsafeCell instead of RefCell since operations are
 // guaranteed not to interfere with each other (the borrows only last until the
@@ -15,28 +16,28 @@ use std::rc::Rc;
 /// will never be more than one reference borrowing the underlying store at a
 /// time.
 #[derive(Default)]
-pub struct Shared<T>(Rc<RefCell<T>>);
+pub struct Shared<T>(Arc<Mutex<T>>);
 
 impl<T> Shared<T> {
     /// Constructs a `Shared` by wrapping the given store.
     #[inline]
     pub fn new(inner: T) -> Self {
-        Shared(Rc::new(RefCell::new(inner)))
+        Shared(Arc::new(Mutex::new(inner)))
     }
 
     pub fn into_inner(self) -> T {
-        match Rc::try_unwrap(self.0) {
-            Ok(inner) => inner.into_inner(),
+        match Arc::try_unwrap(self.0) {
+            Ok(inner) => inner.into_inner().unwrap(),
             _ => panic!("Store is already borrowed"),
         }
     }
 
-    pub fn borrow_mut(&mut self) -> RefMut<T> {
-        self.0.borrow_mut()
+    pub fn borrow_mut(&mut self) -> MutexGuard<T> {
+        self.0.lock().unwrap()
     }
 
-    pub fn borrow(&self) -> Ref<T> {
-        self.0.borrow()
+    pub fn borrow(&self) -> MutexGuard<T> {
+        self.0.lock().unwrap()
     }
 }
 
@@ -52,30 +53,30 @@ impl<T> Clone for Shared<T> {
 impl<T: Read> Read for Shared<T> {
     #[inline]
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        self.0.borrow().get(key)
+        self.0.lock().unwrap().get(key)
     }
 
     #[inline]
     fn get_next(&self, key: &[u8]) -> Result<Option<KV>> {
-        self.0.borrow().get_next(key)
+        self.0.lock().unwrap().get_next(key)
     }
 
     #[inline]
     fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<KV>> {
-        self.0.borrow().get_prev(key)
+        self.0.lock().unwrap().get_prev(key)
     }
 }
 
 impl<W: Write> Write for Shared<W> {
     #[inline]
     fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
-        let mut store = self.0.borrow_mut();
+        let mut store = self.0.lock().unwrap();
         store.put(key, value)
     }
 
     #[inline]
     fn delete(&mut self, key: &[u8]) -> Result<()> {
-        let mut store = self.0.borrow_mut();
+        let mut store = self.0.lock().unwrap();
         store.delete(key)
     }
 }

--- a/src/store/store.rs
+++ b/src/store/store.rs
@@ -32,6 +32,11 @@ pub struct Store<S = DefaultBackingStore> {
     store: Shared<S>,
 }
 
+// TODO: reevaluate the client usage of Store so we don't need these (and we
+// also don't want Shared to have to use Arc<Mutex<T>>)
+unsafe impl<S> Send for Store<S> {}
+unsafe impl<S> Sync for Store<S> {}
+
 impl Store {
     pub fn with_map_store() -> Self {
         use super::MapStore;

--- a/tests/derive_query_call.rs
+++ b/tests/derive_query_call.rs
@@ -33,7 +33,7 @@
 // {
 //     #[call]
 //     deque: Deque<u32>,
-//     _marker: std::marker::PhantomData<T>,
+//     _marker: std::marker::PhantomData<fn(T)>,
 // }
 
 // #[derive(Query, Call)]


### PR DESCRIPTION
This PR makes `AppClient` thread-safe so that it can be used across await boundaries.