### PR TITLE
IBC fixes

### DIFF
--- a/examples/app/main.rs
+++ b/examples/app/main.rs
@@ -14,6 +14,7 @@ pub struct FooCoin();
 
 impl Symbol for FooCoin {
     const INDEX: u8 = 123;
+    const NAME: &'static str = "FOO";
 }
 
 #[orga]

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -557,6 +557,7 @@ mod tests {
 
     impl Symbol for FooCoin {
         const INDEX: u8 = 123;
+        const NAME: &'static str = "FOO";
     }
 
     #[orga]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -362,6 +362,7 @@ mod tests {
     pub struct Simp {}
     impl Symbol for Simp {
         const INDEX: u8 = 12;
+        const NAME: &'static str = "SIMP";
     }
 
     #[orga]

--- a/src/coins/faucet.rs
+++ b/src/coins/faucet.rs
@@ -114,6 +114,7 @@ mod tests {
     struct Simp;
     impl Symbol for Simp {
         const INDEX: u8 = 0;
+        const NAME: &'static str = "SIMP";
     }
 
     #[test]

--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -425,6 +425,7 @@ mod tests {
     struct Simp;
     impl Symbol for Simp {
         const INDEX: u8 = 0;
+        const NAME: &'static str = "SIMP";
     }
 
     #[test]

--- a/src/coins/staking/tests.rs
+++ b/src/coins/staking/tests.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 struct Simp;
 impl Symbol for Simp {
     const INDEX: u8 = 0;
+    const NAME: &'static str = "SIMP";
 }
 
 fn simp_balance(multishare: &MultiShare) -> Amount {
@@ -1515,6 +1516,7 @@ fn redelegate_from_to_two_stakers() {
 struct Alt;
 impl Symbol for Alt {
     const INDEX: u8 = 1;
+    const NAME: &'static str = "ALT";
 }
 
 #[cfg(feature = "abci")]

--- a/src/coins/symbol.rs
+++ b/src/coins/symbol.rs
@@ -5,6 +5,7 @@ pub trait Symbol:
     Sized + State + std::fmt::Debug + 'static + Clone + Send + Default + MigrateFrom + Send + Sync
 {
     const INDEX: u8;
+    const NAME: &'static str;
     fn mint<I: Into<Amount>>(amount: I) -> Coin<Self> {
         Coin::mint(amount)
     }

--- a/src/ibc/query.rs
+++ b/src/ibc/query.rs
@@ -98,6 +98,10 @@ impl AbciQuery for Ibc {
 }
 
 impl Ibc {
+    pub fn query_height(&self) -> Result<u64> {
+        Ok(self.height)
+    }
+
     pub fn query_client_states(&self) -> Result<Vec<IdentifiedClientState>> {
         let mut states = vec![];
         for entry in self.clients.iter()? {

--- a/src/ibc/transfer.rs
+++ b/src/ibc/transfer.rs
@@ -50,9 +50,8 @@ impl Transfer {
     }
 
     pub fn symbol_balance<S: Symbol>(&self, address: Address) -> crate::Result<Amount> {
-        let denom = Denom {
-            inner: vec![S::INDEX].try_into().unwrap(),
-        };
+        let denom = S::NAME.try_into()?;
+
         self.balance(address, denom)
     }
 }
@@ -114,38 +113,13 @@ impl TokenTransferValidationContext for Ibc {
     }
 }
 
-#[orga]
-// TODO: transparent state, simple type, and/or no-version
-#[derive(Clone, Debug)]
-pub struct Denom {
-    pub inner: LengthVec<u8, u8>,
-}
+type Denom = LengthVec<u8, u8>;
 
 impl TryFrom<PrefixedDenom> for Denom {
     type Error = crate::Error;
 
     fn try_from(value: PrefixedDenom) -> crate::Result<Self> {
         value.to_string().try_into()
-    }
-}
-
-impl TryFrom<String> for Denom {
-    type Error = crate::Error;
-
-    fn try_from(value: String) -> crate::Result<Self> {
-        let bytes = value.as_bytes().to_vec();
-        Ok(Self {
-            inner: bytes.try_into()?,
-        })
-    }
-}
-
-impl From<&'static str> for Denom {
-    fn from(value: &'static str) -> Self {
-        let bytes = value.as_bytes().to_vec();
-        Self {
-            inner: bytes.try_into().unwrap(),
-        }
     }
 }
 
@@ -227,7 +201,7 @@ impl<S: Symbol> From<Coin<S>> for PrefixedCoin {
     fn from(value: Coin<S>) -> Self {
         Self {
             amount: value.amount.value.into(),
-            denom: S::INDEX.to_string().parse().unwrap(),
+            denom: S::NAME.parse().unwrap(),
         }
     }
 }

--- a/src/plugins/signer.rs
+++ b/src/plugins/signer.rs
@@ -518,6 +518,7 @@ impl GetNonce for Counter {
 pub struct X(());
 impl Symbol for X {
     const INDEX: u8 = 99;
+    const NAME: &'static str = "X";
 }
 
 #[cfg(test)]

--- a/src/tendermint/client.rs
+++ b/src/tendermint/client.rs
@@ -120,6 +120,7 @@ mod tests {
 
     impl Symbol for FooCoin {
         const INDEX: u8 = 123;
+        const NAME: &'static str = "FOO";
     }
 
     #[orga]


### PR DESCRIPTION
This PR fixes some issues in IBC token transfer relaying, `LengthVec` <-> `String` conversion, and adds a `NAME` const to the symbol trait.