### PR TITLE
Resolve heightless queries against latest snapshot

### DIFF
--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -150,6 +150,10 @@ impl Snapshots {
         self.snapshots.get(&height)
     }
 
+    pub fn get_latest(&self) -> Option<(u64, &Snapshot)> {
+        self.snapshots.iter().next_back().map(|(h, s)| (*h, s))
+    }
+
     pub fn should_create(&self, height: u64) -> bool {
         height > 0 && self.filters.iter().any(|f| f.should_create(height))
     }


### PR DESCRIPTION
Fixes intermittent "Cannot query at height 0" error. The commit process was not atomic since there was time between updating the store height and creating the snapshot which queries would be resolved against, resulting in some queries erroring when the snapshot was not found.