### PR TITLE
Legacy compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ merk-verify = ["merk/verify"]
 merk-full = ["merk/full", "ics23"]
 state-sync = []
 feat-ibc = ["ibc", "bincode", "ics23", "prost-types", "ibc-proto", "tendermint"]
+compat = []
 
 [profile.release]
 lto = true

--- a/macros/src/migrate.rs
+++ b/macros/src/migrate.rs
@@ -89,7 +89,11 @@ impl ToTokens for MigrateInputReceiver {
             }
         } else {
             quote! {
-                Err(::orga::Error::App(format!("Unknown version {}", bytes[0])))
+                Err(::orga::Error::App(format!(
+                    "Unknown version {} for type {}",
+                    bytes[0],
+                    ::std::any::type_name::<Self>(),
+                )))
             }
         };
 

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -258,10 +258,10 @@ impl<A: App> Node<A> {
         let mut store = Store::new(BackingStore::Merk(store));
         let bytes = store.get(&[]).unwrap().unwrap();
 
-        // orga::set_compat_mode(true);
+        orga::set_compat_mode(true);
         let mut app =
             ABCIPlugin::<A>::migrate(store.clone(), store.clone(), &mut bytes.as_slice()).unwrap();
-        // orga::set_compat_mode(false);
+        orga::set_compat_mode(false);
 
         app.attach(store.clone()).unwrap();
         let mut bytes = vec![];

--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -36,18 +36,18 @@ where
 
 impl<K, V, S> MigrateFrom<PoolV0<K, V, S>> for PoolV1<K, V, S>
 where
-    K: Terminated + Encode + Decode + Clone + Send + Sync + MigrateFrom<K> + 'static,
-    V: State + MigrateFrom<V>,
+    K: Terminated + Encode + Decode + Clone + Send + Sync + 'static,
+    V: State,
     S: Symbol,
 {
     fn migrate_from(other: PoolV0<K, V, S>) -> Result<Self> {
         Ok(PoolV1 {
-            contributions: other.contributions.migrate_into()?,
-            rewards: other.rewards.migrate_into()?,
-            shares_issued: other.shares_issued.migrate_into()?,
-            map: other.map.migrate_into()?,
-            rewards_this_period: other.rewards_this_period.migrate_into()?,
-            last_period_entry: other.last_period_entry.migrate_into()?,
+            contributions: other.contributions,
+            rewards: other.rewards,
+            shares_issued: other.shares_issued,
+            map: other.map,
+            rewards_this_period: other.rewards_this_period,
+            last_period_entry: other.last_period_entry,
             drop_errored: false,
             symbol: PhantomData,
         })

--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -2,7 +2,7 @@ use super::{Amount, Balance, Coin, Decimal, Give, Symbol};
 use crate::collections::map::{ChildMut as MapChildMut, Ref as MapRef};
 use crate::collections::{Map, Next};
 use crate::encoding::{Decode, Encode, Terminated};
-use crate::migrate::{MigrateFrom, MigrateInto};
+use crate::migrate::MigrateFrom;
 use crate::orga;
 use crate::state::State;
 use crate::{Error, Result};

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -5,6 +5,7 @@ use crate::coins::{Address, Symbol};
 
 use crate::encoding::{Decode, Encode};
 
+use crate::migrate::MigrateFrom;
 use crate::state::State;
 use crate::{Error, Result};
 
@@ -13,7 +14,7 @@ use std::marker::PhantomData;
 pub const MAX_CALL_SIZE: usize = 65_535;
 pub const NATIVE_CALL_FLAG: u8 = 0xff;
 
-#[orga(skip(Call))]
+#[orga(skip(Call), version = 1)]
 pub struct SdkCompatPlugin<S, T> {
     #[orga(version(V0))]
     #[state(skip)]
@@ -362,6 +363,15 @@ where
         };
 
         self.inner.call(call)
+    }
+}
+
+impl<S: 'static, T: State> MigrateFrom<SdkCompatPluginV0<S, T>> for SdkCompatPluginV1<S, T> {
+    fn migrate_from(value: SdkCompatPluginV0<S, T>) -> Result<Self> {
+        Ok(Self {
+            inner: value.inner,
+            symbol: PhantomData,
+        })
     }
 }
 

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -16,11 +16,11 @@ pub const NATIVE_CALL_FLAG: u8 = 0xff;
 
 #[orga(skip(Call), version = 1)]
 pub struct SdkCompatPlugin<S, T> {
+    #[cfg_attr(feature = "compat", state(skip))]
     #[orga(version(V0))]
-    #[state(skip)]
     pub(crate) symbol: PhantomData<S>,
+    #[cfg_attr(feature = "compat", state(transparent))]
     #[orga(version(V0))]
-    #[state(transparent)]
     pub inner: T,
 
     #[orga(version(V1))]

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -15,7 +15,16 @@ pub const NATIVE_CALL_FLAG: u8 = 0xff;
 
 #[orga(skip(Call))]
 pub struct SdkCompatPlugin<S, T> {
+    #[orga(version(V0))]
+    #[state(skip)]
     pub(crate) symbol: PhantomData<S>,
+    #[orga(version(V0))]
+    #[state(transparent)]
+    pub inner: T,
+
+    #[orga(version(V1))]
+    pub(crate) symbol: PhantomData<S>,
+    #[orga(version(V1))]
     pub inner: T,
 }
 


### PR DESCRIPTION
Tweaks some types to be compatible with legacy releases (via a 'compat' feature flag), and makes it possible to migrate a node with or without compat mode.