### PR TITLE
Add channels attribute macro

### DIFF
--- a/macros/src/channels.rs
+++ b/macros/src/channels.rs
@@ -19,7 +19,7 @@ impl VisitMut for ChannelFilter {
 
             let target: Attribute = if chan_attr.contains_key(&self.channel) {
                 // always true
-                parse_quote! { #[cfg(any(feature = "x", not(feature = "x")))]}
+                parse_quote! { #[cfg(all())]}
             } else {
                 for chan in chan_attr.keys() {
                     if !self.all_channels.contains_key(chan) {
@@ -27,7 +27,7 @@ impl VisitMut for ChannelFilter {
                     }
                 }
                 // always false
-                parse_quote! { #[cfg(all(feature = "x", not(feature = "x")))]}
+                parse_quote! { #[cfg(any())]}
             };
 
             i.meta = target.meta;

--- a/macros/src/channels.rs
+++ b/macros/src/channels.rs
@@ -1,0 +1,80 @@
+use crate::utils::{is_attr_with_ident, path_to_ident};
+use darling::{export::NestedMeta, FromMeta};
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use std::collections::HashMap;
+use syn::{visit_mut::VisitMut, *};
+
+type ChannelList = HashMap<Ident, ()>;
+
+struct ChannelFilter {
+    channel: Ident,
+    all_channels: ChannelList,
+}
+
+impl VisitMut for ChannelFilter {
+    fn visit_attribute_mut(&mut self, i: &mut Attribute) {
+        if is_attr_with_ident(i, "channel") {
+            let chan_attr = ChannelList::from_meta(&i.meta).unwrap();
+
+            let target: Attribute = if chan_attr.contains_key(&self.channel) {
+                // always true
+                parse_quote! { #[cfg(any(feature = "x", not(feature = "x")))]}
+            } else {
+                for chan in chan_attr.keys() {
+                    if !self.all_channels.contains_key(chan) {
+                        panic!("Unexpected channel: {}", chan)
+                    }
+                }
+                // always false
+                parse_quote! { #[cfg(all(feature = "x", not(feature = "x")))]}
+            };
+
+            i.meta = target.meta;
+        }
+    }
+}
+
+fn add_channel_name(item: &mut Item, channel: &Ident) {
+    match item {
+        Item::Impl(item) => {
+            if let box Type::Path(TypePath { path, .. }) = &mut item.self_ty {
+                let generic_args = path.segments.last().unwrap().arguments.clone();
+                let ident = path_to_ident(&path);
+                let ident = format_ident!("{}{}", ident, channel);
+
+                *path = parse_quote! {#ident #generic_args};
+            }
+        }
+        Item::Enum(item) => {
+            item.ident = format_ident!("{}{}", item.ident, channel);
+        }
+        Item::Struct(item) => {
+            item.ident = format_ident!("{}{}", item.ident, channel);
+        }
+        _ => panic!("Unsupported item type"),
+    }
+}
+
+pub fn channels(attr_args: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_args = NestedMeta::parse_meta_list(attr_args.into()).unwrap();
+    let channels = ChannelList::from_list(&attr_args).unwrap();
+
+    let item = parse_macro_input!(item as Item);
+    let all_channels = channels.clone();
+
+    let items = channels.into_keys().map(|channel| {
+        let mut item = item.clone();
+        add_channel_name(&mut item, &channel);
+        visit_mut::visit_item_mut(
+            &mut ChannelFilter {
+                channel,
+                all_channels: all_channels.clone(),
+            },
+            &mut item,
+        );
+        item
+    });
+
+    quote! { #(#items)* }.into()
+}

--- a/macros/src/channels.rs
+++ b/macros/src/channels.rs
@@ -32,6 +32,8 @@ impl VisitMut for ChannelFilter {
 
             i.meta = target.meta;
         }
+
+        visit_mut::visit_attribute_mut(self, i);
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,6 +4,7 @@
 use proc_macro::TokenStream;
 
 mod build_call;
+mod channels;
 mod child;
 mod describe;
 mod encoding;
@@ -46,6 +47,11 @@ pub fn derive_migrate(item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn orga(args: TokenStream, input: TokenStream) -> TokenStream {
     orga::orga(args, input)
+}
+
+#[proc_macro_attribute]
+pub fn channels(args: TokenStream, input: TokenStream) -> TokenStream {
+    channels::channels(args, input)
 }
 
 #[proc_macro_derive(VersionedEncoding, attributes(encoding))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 #![feature(trait_upcasting)]
 
 extern crate self as orga;
-pub use orga_macros::orga;
+pub use orga_macros::{channels, orga};
 
 /// Integration with ABCI.
 pub mod abci;

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -1,0 +1,97 @@
+#![feature(stmt_expr_attributes)]
+use orga::channels;
+
+#[channels(Bar, Baz)]
+#[derive(Clone)]
+pub struct Foo<T> {
+    pub a: u32,
+
+    #[channel(Bar)]
+    pub b: u16,
+
+    pub c: T,
+}
+
+#[channels(Bar, Baz)]
+impl<T: Default> Foo<T> {
+    #[channel(Bar)]
+    const N: u32 = 3;
+
+    #[channel(Baz)]
+    const N: u32 = 1;
+
+    pub fn new() -> Self {
+        Self {
+            #[channel(Bar)]
+            a: 1,
+            #[channel(Baz)]
+            a: 2,
+            #[channel(Bar)]
+            b: 3,
+            c: T::default(),
+        }
+    }
+
+    pub fn my_method(&self, #[channel(Bar)] n: u32) -> u32 {
+        let mut x = 3;
+        #[channel(Baz)]
+        {
+            x += 1;
+            x *= 2;
+        }
+
+        #[channel(Bar, Baz)]
+        x += 1;
+
+        #[channel(Bar)]
+        let res = self.a + x + n;
+
+        #[channel(Baz)]
+        let res = self.a + x;
+
+        let res = self.add_some(res);
+
+        self.add_more(res)
+    }
+
+    #[channel(Bar)]
+    fn add_some(&self, n: u32) -> u32 {
+        n + 3
+    }
+
+    #[channel(Baz)]
+    fn add_some(&self, n: u32) -> u32 {
+        n + 2
+    }
+
+    fn add_more(&self, n: u32) -> u32 {
+        n + Self::N
+    }
+}
+
+#[channels(Bar, Baz)]
+impl<T: Default> Default for Foo<T>
+where
+    T: Clone,
+{
+    fn default() -> Self {
+        Self {
+            #[channel(Bar)]
+            a: 1,
+            #[channel(Baz)]
+            a: 2,
+            #[channel(Bar)]
+            b: 3,
+            c: T::default(),
+        }
+    }
+}
+
+#[test]
+fn two_channels() {
+    let a = FooBar::<u8>::new();
+    let b = FooBaz::<u8>::new();
+    assert_eq!(a.a, 1);
+    assert_eq!(b.a, 2);
+    assert_eq!(a.my_method(3), b.my_method());
+}


### PR DESCRIPTION
This PR adds a standalone `#[channels]` macro which works like `#[orga(channels)]`, but can be used in any valid attribute position, instead of only on struct fields and impl items. A future PR will update the `orga` macro to use this one internally.