### PR TITLE
Queryable upgrade signals

### DIFF
--- a/src/coins/mod.rs
+++ b/src/coins/mod.rs
@@ -219,7 +219,7 @@ impl From<Address> for [u8; Address::LENGTH] {
 }
 
 #[orga]
-#[derive(Clone, Debug, Next, Copy)]
+#[derive(Clone, Debug, Next, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VersionedAddress {
     bytes: [u8; Address::LENGTH],
 }

--- a/src/plugins/abci.rs
+++ b/src/plugins/abci.rs
@@ -105,6 +105,7 @@ pub struct InitChainCtx {
     pub initial_height: i64,
 }
 
+#[derive(Encode, Decode, Debug)]
 pub struct Validator {
     pub pubkey: [u8; 32],
     pub power: u64,

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -24,6 +24,7 @@ type PubKey = [u8; 32];
 pub type Version = LengthVec<u8, u8>;
 
 #[orga]
+#[derive(Debug, Clone)]
 pub struct Signal {
     pub version: Version,
     pub time: i64,
@@ -31,7 +32,7 @@ pub struct Signal {
 
 #[orga(skip(Default), version = 1)]
 pub struct Upgrade {
-    signals: Map<PubKey, Signal>,
+    pub signals: Map<PubKey, Signal>,
     pub threshold: Decimal,
     pub activation_delay_seconds: i64,
     pub rate_limit_seconds: i64,


### PR DESCRIPTION
This PR allows querying the `signals` map in the Upgrade module.