### PR TITLE
Store fixes

### DIFF
--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -276,10 +276,11 @@ impl<A: App> Node<A> {
             )
             .unwrap();
         if let BackingStore::Merk(merk_store) = store.into_backing_store().into_inner() {
-            merk_store
-                .into_inner()
+            let mut store = merk_store.into_inner();
+            store
                 .write(vec![(b"consensus_version".to_vec(), Some(version))])
                 .unwrap();
+            store.into_merk().repair().unwrap();
         } else {
             unreachable!();
         }

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -280,6 +280,7 @@ impl<A: App> Node<A> {
             store
                 .write(vec![(b"consensus_version".to_vec(), Some(version))])
                 .unwrap();
+            #[cfg(feature = "compat")]
             store.into_merk().repair().unwrap();
         } else {
             unreachable!();

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -130,6 +130,10 @@ impl MerkStore {
         self.merk.as_ref().unwrap()
     }
 
+    pub fn into_merk(self) -> Merk {
+        self.merk.unwrap()
+    }
+
     pub(crate) fn snapshots(&self) -> &snapshot::Snapshots {
         &self.snapshots
     }


### PR DESCRIPTION
This is a bugfix PR:
- Rebuild tree after migrations (when `compat` feature is enabled), so that all nodes are rehashed with the correct hash function (Merk changed from Blake3 to SHA2).
- Don't retain a self-referential `ChunkProducer` in ABCI snapshot chunk production, to avoid a possible node crash. This change has a negative performance impact for creating chunks since now the trunk chunk will be recreated for each request, but this can be fixed in Merk by refactoring `ChunkProducer` to not retain a db reference.