### PR TITLE
Remove `compat` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ merk-verify = ["merk/verify"]
 merk-full = ["merk/full", "ics23"]
 state-sync = []
 feat-ibc = ["ibc", "bincode", "ics23", "prost-types", "ibc-proto", "tendermint"]
-compat = []
 
 [profile.release]
 lto = true

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -280,8 +280,6 @@ impl<A: App> Node<A> {
             store
                 .write(vec![(b"consensus_version".to_vec(), Some(version))])
                 .unwrap();
-            #[cfg(feature = "compat")]
-            store.into_merk().repair().unwrap();
         } else {
             unreachable!();
         }

--- a/src/coins/staking/mod.rs
+++ b/src/coins/staking/mod.rs
@@ -27,98 +27,6 @@ pub const UNBONDING_SECONDS: u64 = 10; // 10 seconds
 pub const UNBONDING_SECONDS: u64 = 60 * 60 * 24 * 14; // 2 weeks
 const EDIT_INTERVAL_SECONDS: u64 = 60 * 60 * 24; // 1 day
 
-// TODO: remove this once compat mode format is deprecated
-#[cfg(feature = "compat")]
-#[orga(version = 1)]
-#[state(allow_prefix_overlap)]
-pub struct Staking<S: Symbol> {
-    #[orga(version(V0))]
-    pub max_validators: u64,
-    #[orga(version(V0))]
-    pub min_self_delegation_min: u64,
-    #[orga(version(V0))]
-    unbonding_seconds: u64,
-    #[orga(version(V0))]
-    pub max_offline_blocks: u64,
-    #[orga(version(V0))]
-    pub slash_fraction_double_sign: Decimal,
-    #[orga(version(V0))]
-    pub slash_fraction_downtime: Decimal,
-    #[orga(version(V0))]
-    pub downtime_jail_seconds: u64,
-    #[orga(version(V0))]
-    #[state(prefix(0))]
-    validators: Pool<Address, Validator<S>, S>,
-    #[orga(version(V0))]
-    #[state(prefix(15))]
-    unbonding_delegation_queue: Deque<UnbondingDelegationEntry>,
-    #[orga(version(V0))]
-    #[state(prefix(16))]
-    redelegation_queue: Deque<RedelegationEntry>,
-    #[orga(version(V0))]
-    #[state(prefix(2))]
-    consensus_keys: Map<Address, [u8; 32]>,
-    #[orga(version(V0))]
-    #[state(prefix(3))]
-    last_signed_block: Map<[u8; 20], u64>,
-    #[orga(version(V0))]
-    #[state(prefix(4))]
-    validators_by_power: EntryMap<ValidatorPowerEntry>,
-    #[orga(version(V0))]
-    #[state(prefix(5))]
-    last_validator_powers: Map<Address, u64>,
-    #[orga(version(V0))]
-    #[state(prefix(7))]
-    last_indexed_power: Map<Address, u64>,
-    #[orga(version(V0))]
-    #[state(prefix(8))]
-    address_for_tm_hash: Map<[u8; 20], Address>,
-    #[orga(version(V0))]
-    #[state(prefix(14))]
-    validator_queue: EntryMap<ValidatorQueueEntry>,
-    #[orga(version(V0))]
-    #[state(prefix(17))]
-    delegation_index: Map<Address, Map<Address, ()>>,
-
-    #[orga(version(V1))]
-    validators: Pool<Address, Validator<S>, S>,
-    #[orga(version(V1))]
-    pub min_self_delegation_min: u64,
-    #[orga(version(V1))]
-    consensus_keys: Map<Address, [u8; 32]>,
-    #[orga(version(V1))]
-    last_signed_block: Map<[u8; 20], u64>,
-    #[orga(version(V1))]
-    validators_by_power: EntryMap<ValidatorPowerEntry>,
-    #[orga(version(V1))]
-    last_validator_powers: Map<Address, u64>,
-    #[orga(version(V1))]
-    pub max_validators: u64,
-    #[orga(version(V1))]
-    last_indexed_power: Map<Address, u64>,
-    #[orga(version(V1))]
-    address_for_tm_hash: Map<[u8; 20], Address>,
-    #[orga(version(V1))]
-    unbonding_seconds: u64,
-    #[orga(version(V1))]
-    pub max_offline_blocks: u64,
-    #[orga(version(V1))]
-    pub slash_fraction_double_sign: Decimal,
-    #[orga(version(V1))]
-    pub slash_fraction_downtime: Decimal,
-    #[orga(version(V1))]
-    pub downtime_jail_seconds: u64,
-    #[orga(version(V1))]
-    validator_queue: EntryMap<ValidatorQueueEntry>,
-    #[orga(version(V1))]
-    unbonding_delegation_queue: Deque<UnbondingDelegationEntry>,
-    #[orga(version(V1))]
-    redelegation_queue: Deque<RedelegationEntry>,
-    #[orga(version(V1))]
-    delegation_index: Map<Address, Map<Address, ()>>,
-}
-
-#[cfg(not(feature = "compat"))]
 #[orga(version = 1)]
 pub struct Staking<S: Symbol> {
     validators: Pool<Address, Validator<S>, S>,
@@ -142,27 +50,8 @@ pub struct Staking<S: Symbol> {
 }
 
 impl<S: Symbol> MigrateFrom<StakingV0<S>> for StakingV1<S> {
-    fn migrate_from(value: StakingV0<S>) -> Result<Self> {
-        Ok(Self {
-            max_validators: value.max_validators,
-            min_self_delegation_min: value.min_self_delegation_min,
-            unbonding_seconds: value.unbonding_seconds,
-            max_offline_blocks: value.max_offline_blocks,
-            slash_fraction_double_sign: value.slash_fraction_double_sign,
-            slash_fraction_downtime: value.slash_fraction_downtime,
-            downtime_jail_seconds: value.downtime_jail_seconds,
-            validators: value.validators,
-            unbonding_delegation_queue: value.unbonding_delegation_queue,
-            redelegation_queue: value.redelegation_queue,
-            consensus_keys: value.consensus_keys,
-            last_signed_block: value.last_signed_block,
-            validators_by_power: value.validators_by_power,
-            last_validator_powers: value.last_validator_powers,
-            last_indexed_power: value.last_indexed_power,
-            address_for_tm_hash: value.address_for_tm_hash,
-            validator_queue: value.validator_queue,
-            delegation_index: value.delegation_index,
-        })
+    fn migrate_from(_value: StakingV0<S>) -> Result<Self> {
+        unreachable!()
     }
 }
 

--- a/src/ibc/migration.rs
+++ b/src/ibc/migration.rs
@@ -5,19 +5,7 @@ use crate::{migrate::MigrateFrom, state::State};
 /// This migration resets all IBC state.
 impl MigrateFrom<IbcV0> for IbcV1 {
     fn migrate_from(mut value: IbcV0) -> crate::Result<Self> {
-        // TODO: implement actual IBC migration
-
-        value
-            .root_store
-            .remove_range(b"a".to_vec()..b"z".to_vec())?;
-
-        value.local_store.remove_range(..)?;
-
-        let mut out = vec![];
-        value.root_store.flush(&mut out)?;
-        value.local_store.flush(&mut out)?;
-
-        Ok(Self::default())
+        unreachable!()
     }
 }
 

--- a/src/ibc/migration.rs
+++ b/src/ibc/migration.rs
@@ -1,10 +1,8 @@
 use super::{IbcV0, IbcV1, Timestamp};
-use crate::{migrate::MigrateFrom, state::State};
+use crate::migrate::MigrateFrom;
 
-/// Upgrade from ibc-rs v0.15 -> v0.40.
-/// This migration resets all IBC state.
 impl MigrateFrom<IbcV0> for IbcV1 {
-    fn migrate_from(mut value: IbcV0) -> crate::Result<Self> {
+    fn migrate_from(_value: IbcV0) -> crate::Result<Self> {
         unreachable!()
     }
 }

--- a/src/ibc/mod.rs
+++ b/src/ibc/mod.rs
@@ -64,76 +64,40 @@ pub const IBC_QUERY_PATH: &str = "store/ibc/key";
 
 #[orga(version = 1)]
 pub struct Ibc {
-    #[orga(version(V0))]
-    _bytes0: [u8; 32],
-    #[orga(version(V0))]
-    _bytes1: [u8; 32],
-    #[orga(version(V0))]
-    _bytes2: [u8; 23],
-
-    #[orga(version(V0))]
-    #[state(prefix(b""))]
-    local_store: Store,
-
-    #[orga(version(V0))]
-    #[state(absolute_prefix(b""))]
-    root_store: Store,
-
-    #[orga(version(V1))]
     height: u64,
-
-    #[orga(version(V1))]
     host_consensus_states: Deque<ConsensusState>,
-
-    #[orga(version(V1))]
     channel_counter: u64,
-
-    #[orga(version(V1))]
     connection_counter: u64,
-
-    #[orga(version(V1))]
     client_counter: u64,
-
-    #[orga(version(V1))]
     pub transfer: Transfer,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"clients/"))]
     clients: Map<ClientId, Client>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"connections/"))]
     connections: Map<ConnectionId, ConnectionEnd>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"channelEnds/"))]
     channel_ends: Map<PortChannel, ChannelEnd>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"nextSequenceSend/"))]
     next_sequence_send: Map<PortChannel, Number>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"nextSequenceRecv/"))]
     next_sequence_recv: Map<PortChannel, Number>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"nextSequenceAck/"))]
     next_sequence_ack: Map<PortChannel, Number>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"commitments/"))]
     commitments: Map<PortChannelSequence, Vec<u8>>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"receipts/"))]
     receipts: Map<PortChannelSequence, ()>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"acks/"))]
     acks: Map<PortChannelSequence, Vec<u8>>,
 
-    #[orga(version(V1))]
     #[state(absolute_prefix(b""))]
     store: Store,
 }
@@ -216,17 +180,18 @@ pub struct Timestamp {
     inner: IbcTimestamp,
 }
 
+// TODO: replace when macro can specify min version
 impl Migrate for Timestamp {
     fn migrate(_src: Store, _dest: Store, bytes: &mut &[u8]) -> OrgaResult<Self> {
-        if bytes[0] != 0 {
+        if bytes[0] != 1 {
             return Err(crate::Error::Ibc(format!(
                 "Invalid timestamp version: {}",
                 bytes[0]
             )));
         }
-        let ts_bytes: [u8; 16] = (&bytes[1..17]).try_into().unwrap();
-        *bytes = &bytes[17..];
-        i128::from_le_bytes(ts_bytes).migrate_into()
+        *bytes = &bytes[1..];
+
+        Timestamp::load(Store::default(), bytes)
     }
 }
 

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -358,7 +358,7 @@ where
 }
 
 impl<S: 'static, T: State> MigrateFrom<SdkCompatPluginV0<S, T>> for SdkCompatPluginV1<S, T> {
-    fn migrate_from(value: SdkCompatPluginV0<S, T>) -> Result<Self> {
+    fn migrate_from(_value: SdkCompatPluginV0<S, T>) -> Result<Self> {
         unreachable!()
     }
 }

--- a/src/plugins/sdk_compat.rs
+++ b/src/plugins/sdk_compat.rs
@@ -16,16 +16,7 @@ pub const NATIVE_CALL_FLAG: u8 = 0xff;
 
 #[orga(skip(Call), version = 1)]
 pub struct SdkCompatPlugin<S, T> {
-    #[cfg_attr(feature = "compat", state(skip))]
-    #[orga(version(V0))]
     pub(crate) symbol: PhantomData<S>,
-    #[cfg_attr(feature = "compat", state(transparent))]
-    #[orga(version(V0))]
-    pub inner: T,
-
-    #[orga(version(V1))]
-    pub(crate) symbol: PhantomData<S>,
-    #[orga(version(V1))]
     pub inner: T,
 }
 
@@ -368,10 +359,7 @@ where
 
 impl<S: 'static, T: State> MigrateFrom<SdkCompatPluginV0<S, T>> for SdkCompatPluginV1<S, T> {
     fn migrate_from(value: SdkCompatPluginV0<S, T>) -> Result<Self> {
-        Ok(Self {
-            inner: value.inner,
-            symbol: PhantomData,
-        })
+        unreachable!()
     }
 }
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -36,9 +36,6 @@ pub struct Upgrade {
     pub threshold: Decimal,
     pub activation_delay_seconds: i64,
     pub rate_limit_seconds: i64,
-    #[orga(version(V0))]
-    pub current_version: Version,
-    #[orga(version(V1))]
     #[state(absolute_prefix(b"/version"))]
     // TODO: use Value/Box instead of Map<(), _>
     pub current_version: Map<(), Version>,
@@ -62,16 +59,7 @@ impl Default for Upgrade {
 
 impl MigrateFrom<UpgradeV0> for UpgradeV1 {
     fn migrate_from(prev: UpgradeV0) -> Result<Self> {
-        let mut current_version = Map::new();
-        current_version.insert((), prev.current_version)?;
-
-        Ok(Self {
-            signals: prev.signals,
-            threshold: prev.threshold,
-            activation_delay_seconds: prev.activation_delay_seconds,
-            rate_limit_seconds: prev.rate_limit_seconds,
-            current_version,
-        })
+        unreachable!()
     }
 }
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -58,7 +58,7 @@ impl Default for Upgrade {
 }
 
 impl MigrateFrom<UpgradeV0> for UpgradeV1 {
-    fn migrate_from(prev: UpgradeV0) -> Result<Self> {
+    fn migrate_from(_prev: UpgradeV0) -> Result<Self> {
         unreachable!()
     }
 }


### PR DESCRIPTION
This PR removes the `compat` feature and prunes legacy state formats.