### PR TITLE
Snapshot perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ abci2 = { git = "https://github.com/nomic-io/abci2", rev = "26b345ed839123f33596
 tendermint-rpc = { version = "=0.32.0", features = ["http-client"], optional = true }
 tendermint = { version = "=0.32.0", optional = true }
 tendermint-proto = { version = "=0.32.0" }
-merk = { git = "https://github.com/nomic-io/merk", rev = "aaa870e603b0cbe8437aee5c9538926ed078a082", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "e2e0d331e74c47f113f09d6a08e488abe9032a74", optional = true, default-features = false }
 orga-macros = { path = "macros", version = "0.3.1" }
 seq-macro = "0.3.3"
 log = "0.4.17"

--- a/src/abci/node.rs
+++ b/src/abci/node.rs
@@ -548,6 +548,7 @@ impl<A: App> Application for InternalApp<ABCIPlugin<A>> {
 
         let proof_builder = store.into_proof_builder_memsnapshot()?;
         let (proof_bytes, ss) = proof_builder.build()?;
+        let ss = ss.into_inner();
         let root_hash = ss.use_snapshot(|ss| ss.root_hash());
         merk_store
             .borrow_mut()

--- a/src/merk/memsnapshot.rs
+++ b/src/merk/memsnapshot.rs
@@ -1,0 +1,40 @@
+use crate::{
+    store::{Read, Shared, Write},
+    Result,
+};
+
+use super::MerkStore;
+
+pub struct MemSnapshot {
+    pub(crate) snapshot: merk::snapshot::StaticSnapshot,
+    pub(crate) merk_store: Shared<MerkStore>,
+}
+
+impl MemSnapshot {
+    pub fn use_snapshot<R, F: FnOnce(&merk::Snapshot) -> R>(&self, f: F) -> R {
+        let store = self.merk_store.borrow();
+        let db = store.merk().db();
+        let ss = unsafe { self.snapshot.with_db(db) };
+        f(&ss)
+    }
+}
+
+impl Read for MemSnapshot {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.use_snapshot(|ss| ss.get(key))?)
+    }
+
+    fn get_next(&self, key: &[u8]) -> Result<Option<crate::store::KV>> {
+        self.use_snapshot(|ss| {
+            let iter = ss.raw_iter();
+            super::store::get_next(iter, key)
+        })
+    }
+
+    fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<crate::store::KV>> {
+        self.use_snapshot(|ss| {
+            let iter = ss.raw_iter();
+            super::store::get_prev(iter, key)
+        })
+    }
+}

--- a/src/merk/memsnapshot.rs
+++ b/src/merk/memsnapshot.rs
@@ -1,5 +1,5 @@
 use crate::{
-    store::{Read, Shared, Write},
+    store::{Read, Shared},
     Result,
 };
 

--- a/src/merk/mod.rs
+++ b/src/merk/mod.rs
@@ -2,6 +2,8 @@ mod client;
 #[cfg(feature = "merk-full")]
 pub mod ics23;
 #[cfg(feature = "merk-full")]
+pub mod memsnapshot;
+#[cfg(feature = "merk-full")]
 mod proofbuilder;
 #[cfg(feature = "merk-verify")]
 pub mod proofstore;

--- a/src/merk/proofbuilder.rs
+++ b/src/merk/proofbuilder.rs
@@ -5,7 +5,7 @@ use super::memsnapshot::MemSnapshot;
 use super::snapshot::Snapshot;
 use super::MerkStore;
 use crate::store::Shared;
-use crate::store::{self, Write};
+use crate::store::{self};
 use crate::Result;
 use merk::proofs::query::Query;
 use store::Read;
@@ -113,7 +113,7 @@ impl Prove for Snapshot {
     }
 }
 
-impl<'a> Prove for MemSnapshot {
+impl Prove for MemSnapshot {
     fn prove(&self, query: Query) -> Result<Vec<u8>> {
         Ok(self.use_snapshot(|ss| ss.prove(query))?)
     }

--- a/src/merk/proofbuilder.rs
+++ b/src/merk/proofbuilder.rs
@@ -38,12 +38,12 @@ impl<T: Prove> ProofBuilder<T> {
 
     /// Builds a Merk proof including all the data accessed during the life of
     /// the `ProofBuilder`.
-    pub fn build(self) -> Result<(Vec<u8>, T)> {
+    pub fn build(self) -> Result<(Vec<u8>, Shared<T>)> {
         let store = self.store.borrow();
         let query = self.query.take();
         let proof = store.prove(query)?;
         drop(store);
-        Ok((proof, self.store.into_inner()))
+        Ok((proof, self.store))
     }
 }
 

--- a/src/merk/snapshot.rs
+++ b/src/merk/snapshot.rs
@@ -48,11 +48,15 @@ impl Read for Snapshot {
     }
 
     fn get_next(&self, key: &[u8]) -> Result<Option<crate::store::KV>> {
-        super::store::get_next(&self.checkpoint.borrow(), key)
+        let cp = self.checkpoint.borrow();
+        let iter = cp.raw_iter();
+        super::store::get_next(iter, key)
     }
 
     fn get_prev(&self, key: Option<&[u8]>) -> Result<Option<crate::store::KV>> {
-        super::store::get_prev(&self.checkpoint.borrow(), key)
+        let cp = self.checkpoint.borrow();
+        let iter = cp.raw_iter();
+        super::store::get_prev(iter, key)
     }
 }
 

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -162,18 +162,17 @@ impl Read for MerkStore {
     }
 
     fn get_next(&self, start: &[u8]) -> Result<Option<KV>> {
-        get_next(self.merk(), start)
+        get_next(self.merk().raw_iter(), start)
     }
 
     fn get_prev(&self, end: Option<&[u8]>) -> Result<Option<KV>> {
-        get_prev(self.merk(), end)
+        get_prev(self.merk().raw_iter(), end)
     }
 }
 
-pub(crate) fn get_next(merk: &Merk, start: &[u8]) -> Result<Option<KV>> {
+pub(crate) fn get_next(mut iter: merk::rocksdb::DBRawIterator, start: &[u8]) -> Result<Option<KV>> {
     // TODO: use an iterator in merk which steps through in-memory nodes
     // (loading if necessary)
-    let mut iter = merk.raw_iter();
     iter.seek(start);
 
     if !iter.valid() {
@@ -197,10 +196,12 @@ pub(crate) fn get_next(merk: &Merk, start: &[u8]) -> Result<Option<KV>> {
     Ok(Some((key.to_vec(), value.to_vec())))
 }
 
-pub(crate) fn get_prev(merk: &Merk, end: Option<&[u8]>) -> Result<Option<KV>> {
+pub(crate) fn get_prev(
+    mut iter: merk::rocksdb::DBRawIterator,
+    end: Option<&[u8]>,
+) -> Result<Option<KV>> {
     // TODO: use an iterator in merk which steps through in-memory nodes
     // (loading if necessary)
-    let mut iter = merk.raw_iter();
     if let Some(key) = end {
         iter.seek(key);
 

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -3,7 +3,6 @@ use crate::error::{Error, Result};
 use crate::store::*;
 use merk::snapshot::StaticSnapshot;
 use merk::{restore::Restorer, tree::Tree, BatchEntry, Merk, Op};
-use std::mem::ManuallyDrop;
 use std::path::{Path, PathBuf};
 use std::{collections::BTreeMap, convert::TryInto};
 use tendermint_proto::v0_34::abci::{self, *};
@@ -136,14 +135,6 @@ impl MerkStore {
 
     pub fn into_merk(self) -> Merk {
         self.merk.unwrap()
-    }
-
-    pub(crate) fn snapshots(&self) -> &snapshot::Snapshots {
-        &self.snapshots
-    }
-
-    pub(crate) fn mem_snapshots(&self) -> &BTreeMap<u64, StaticSnapshot> {
-        &self.mem_snapshots
     }
 
     pub(crate) fn mem_snapshots_mut(&mut self) -> &mut BTreeMap<u64, StaticSnapshot> {

--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "merk-full")]
+use crate::merk::memsnapshot::MemSnapshot;
+#[cfg(feature = "merk-full")]
 use crate::merk::snapshot::Snapshot;
 #[cfg(feature = "merk-verify")]
 use crate::merk::ProofStore;
@@ -27,9 +29,13 @@ pub enum BackingStore {
     #[cfg(feature = "merk-full")]
     ProofBuilderSnapshot(ProofBuilder<Snapshot>),
     #[cfg(feature = "merk-full")]
+    ProofBuilderMemSnapshot(ProofBuilder<MemSnapshot>),
+    #[cfg(feature = "merk-full")]
     Merk(Shared<MerkStore>),
     #[cfg(feature = "merk-full")]
     Snapshot(Shared<Snapshot>),
+    #[cfg(feature = "merk-full")]
+    MemSnapshot(Shared<MemSnapshot>),
     #[cfg(feature = "merk-verify")]
     ProofMap(Shared<ProofStore>),
 }
@@ -55,9 +61,13 @@ impl Read for BackingStore {
             #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilderSnapshot(ref builder) => builder.get(key),
             #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(ref builder) => builder.get(key),
+            #[cfg(feature = "merk-full")]
             BackingStore::Merk(ref store) => store.get(key),
             #[cfg(feature = "merk-full")]
             BackingStore::Snapshot(ref store) => store.get(key),
+            #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(ref store) => store.get(key),
             #[cfg(feature = "merk-verify")]
             BackingStore::ProofMap(ref map) => map.get(key),
         }
@@ -77,9 +87,13 @@ impl Read for BackingStore {
             #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilderSnapshot(ref builder) => builder.get_next(key),
             #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(ref builder) => builder.get_next(key),
+            #[cfg(feature = "merk-full")]
             BackingStore::Merk(ref store) => store.get_next(key),
             #[cfg(feature = "merk-full")]
             BackingStore::Snapshot(ref store) => store.get_next(key),
+            #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(ref store) => store.get_next(key),
             #[cfg(feature = "merk-verify")]
             BackingStore::ProofMap(ref map) => map.get_next(key),
         }
@@ -99,9 +113,13 @@ impl Read for BackingStore {
             #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilderSnapshot(ref builder) => builder.get_prev(key),
             #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(ref builder) => builder.get_prev(key),
+            #[cfg(feature = "merk-full")]
             BackingStore::Merk(ref store) => store.get_prev(key),
             #[cfg(feature = "merk-full")]
             BackingStore::Snapshot(ref store) => store.get_prev(key),
+            #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(ref store) => store.get_prev(key),
             #[cfg(feature = "merk-verify")]
             BackingStore::ProofMap(ref map) => map.get_prev(key),
         }
@@ -127,12 +145,20 @@ impl Write for BackingStore {
                 panic!("put() is not implemented for Snapshot")
             }
             #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(_) => {
+                panic!("put() is not implemented for MemSnapshot")
+            }
+            #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilder(_) => {
                 panic!("put() is not implemented for ProofBuilder")
             }
             #[cfg(feature = "merk-full")]
             BackingStore::ProofBuilderSnapshot(_) => {
                 panic!("put() is not implemented for ProofBuilderSnapshot")
+            }
+            #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(_) => {
+                panic!("put() is not implemented for ProofBuilderMemSnapshot")
             }
             #[cfg(feature = "merk-verify")]
             BackingStore::ProofMap(_) => {
@@ -163,8 +189,16 @@ impl Write for BackingStore {
                 panic!("delete() is not implemented for ProofBuilderSnapshot")
             }
             #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(_) => {
+                panic!("delete() is not implemented for ProofBuilderMemSnapshot")
+            }
+            #[cfg(feature = "merk-full")]
             BackingStore::Snapshot(_) => {
                 panic!("delete() is not implemented for Snapshot")
+            }
+            #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(_) => {
+                panic!("delete() is not implemented for MemSnapshot")
             }
             #[cfg(feature = "merk-verify")]
             BackingStore::ProofMap(_) => {
@@ -193,6 +227,28 @@ impl BackingStore {
             BackingStore::ProofBuilderSnapshot(builder) => Ok(builder),
             _ => Err(Error::Downcast(
                 "Failed to downcast backing store to proof builder snapshot".into(),
+            )),
+        }
+    }
+
+    #[cfg(feature = "merk-full")]
+    pub fn into_memsnapshot(self) -> Result<Shared<MemSnapshot>> {
+        match self {
+            #[cfg(feature = "merk-full")]
+            BackingStore::MemSnapshot(ss) => Ok(ss),
+            _ => Err(Error::Downcast(
+                "Failed to downcast backing store to memsnapshot".into(),
+            )),
+        }
+    }
+
+    #[cfg(feature = "merk-full")]
+    pub fn into_proof_builder_memsnapshot(self) -> Result<ProofBuilder<MemSnapshot>> {
+        match self {
+            #[cfg(feature = "merk-full")]
+            BackingStore::ProofBuilderMemSnapshot(builder) => Ok(builder),
+            _ => Err(Error::Downcast(
+                "Failed to downcast backing store to proof builder memsnapshot".into(),
             )),
         }
     }


### PR DESCRIPTION
This PR replaces the state snapshots used for historical queries to be backed by RocksDB snapshots (in–memory) rather than checkpoints (on-disk). This should fix performance issues seen on nodes in the wild, as the stacked checkpoints were causing huge amounts of unnecessary compaction work.

Checkpoints are still used for state sync snapshots, and still may have some amount of performance issues which could be improved, but their impact is much smaller since they have a 1000-block interval as opposed to every block.