### PR TITLE
Snapshot query fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ abci2 = { git = "https://github.com/nomic-io/abci2", rev = "26b345ed839123f33596
 tendermint-rpc = { version = "=0.32.0", features = ["http-client"], optional = true }
 tendermint = { version = "=0.32.0", optional = true }
 tendermint-proto = { version = "=0.32.0" }
-merk = { git = "https://github.com/nomic-io/merk", rev = "fe7fc2ff8ef9878d842183af24cd79a7c5d52508", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "34c237624f923c05137e7cb22edf5726482b79ce", optional = true, default-features = false }
 orga-macros = { path = "macros", version = "0.3.1" }
 seq-macro = "0.3.3"
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ abci2 = { git = "https://github.com/nomic-io/abci2", rev = "26b345ed839123f33596
 tendermint-rpc = { version = "=0.32.0", features = ["http-client"], optional = true }
 tendermint = { version = "=0.32.0", optional = true }
 tendermint-proto = { version = "=0.32.0" }
-merk = { git = "https://github.com/nomic-io/merk", rev = "e2e0d331e74c47f113f09d6a08e488abe9032a74", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "fe7fc2ff8ef9878d842183af24cd79a7c5d52508", optional = true, default-features = false }
 orga-macros = { path = "macros", version = "0.3.1" }
 seq-macro = "0.3.3"
 log = "0.4.17"

--- a/src/merk/store.rs
+++ b/src/merk/store.rs
@@ -137,8 +137,8 @@ impl MerkStore {
         self.merk.unwrap()
     }
 
-    pub(crate) fn mem_snapshots_mut(&mut self) -> &mut BTreeMap<u64, StaticSnapshot> {
-        &mut self.mem_snapshots
+    pub(crate) fn mem_snapshots(&self) -> &BTreeMap<u64, StaticSnapshot> {
+        &self.mem_snapshots
     }
 }
 


### PR DESCRIPTION
Fixes a panic due to dropping the `StaticSnapshot` when a query fails. Refactored to more simply clone `StaticSnapshot`s when using them instead of pulling them out of their collection.