### PR TITLE
Add use_merk() for MemSnapshot

### DIFF
--- a/src/store/backingstore.rs
+++ b/src/store/backingstore.rs
@@ -295,6 +295,14 @@ impl BackingStore {
                 let borrow = borrow.checkpoint.borrow();
                 f(&borrow)
             }
+            BackingStore::MemSnapshot(store) => {
+                // TODO: remove use_merk support for MemSnapshot once
+                // constructing proofs from a snapshot is supported
+                let borrow = store.borrow();
+                let borrow = borrow.merk_store.borrow();
+                let borrow = borrow.merk();
+                f(borrow)
+            }
             _ => panic!("Cannot get MerkStore from BackingStore variant"),
         }
     }


### PR DESCRIPTION
This PR adds support for `BackingStore::MemSnapshot::use_merk()`.