### PR TITLE
Upgrade merk dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ abci2 = { git = "https://github.com/nomic-io/abci2", rev = "26b345ed839123f33596
 tendermint-rpc = { version = "=0.32.0", features = ["http-client"], optional = true }
 tendermint = { version = "=0.32.0", optional = true }
 tendermint-proto = { version = "=0.32.0" }
-merk = { git = "https://github.com/nomic-io/merk", rev = "34c237624f923c05137e7cb22edf5726482b79ce", optional = true, default-features = false }
+merk = { git = "https://github.com/nomic-io/merk", rev = "db64bb3024eee6c1e77861d645d20110b1fe549b", optional = true, default-features = false }
 orga-macros = { path = "macros", version = "0.3.1" }
 seq-macro = "0.3.3"
 log = "0.4.17"


### PR DESCRIPTION
This PR updates merk to fix the memory leak introduced with static tree snapshots.