### PR TITLE
Fix encoding::Decoder version byte check

### DIFF
--- a/src/encoding/decoder.rs
+++ b/src/encoding/decoder.rs
@@ -21,8 +21,11 @@ impl<R: Read> Decoder<R> {
     where
         U: Decode,
     {
-        if self.field_count == 0 && !compat_mode() && self.version == 0 {
-            let _version_byte = u8::decode(&mut self.bytes)?;
+        if self.field_count == 0 && !compat_mode() {
+            let version_byte = u8::decode(&mut self.bytes)?;
+            if version_byte != self.version {
+                return Err(ed::Error::UnexpectedByte(version_byte));
+            }
         }
         let res = U::decode(&mut self.bytes);
         self.field_count += 1;

--- a/src/encoding/decoder.rs
+++ b/src/encoding/decoder.rs
@@ -42,3 +42,31 @@ impl<R: Read> Decoder<R> {
         Ok(value.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn simple() {
+        let bytes = [0, 1];
+        let mut bytes = &bytes[..];
+        let mut decoder = super::Decoder::new(&mut bytes, 0);
+        assert_eq!(decoder.decode_child::<u8>().unwrap(), 1);
+    }
+
+    #[test]
+    fn higher_version() {
+        let bytes = [10, 1];
+        let mut bytes = &bytes[..];
+        let mut decoder = super::Decoder::new(&mut bytes, 10);
+        assert_eq!(decoder.decode_child::<u8>().unwrap(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnexpectedByte(0)")]
+    fn incorrect_version() {
+        let bytes = [0, 1];
+        let mut bytes = &bytes[..];
+        let mut decoder = super::Decoder::new(&mut bytes, 1);
+        decoder.decode_child::<u8>().unwrap();
+    }
+}


### PR DESCRIPTION
This was previously incorrect due to not actually making use of the version byte, and by only consuming the version byte for types with `version = 0`.