### PR TITLE
Client state index

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -346,7 +346,7 @@ impl<T: FromStr + ToString> EofTerminatedString<T> {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Default)]
 pub struct FixedString<const S: &'static str>;
 
 impl<const S: &'static str> Migrate for FixedString<S> {}

--- a/src/ibc/client_contexts.rs
+++ b/src/ibc/client_contexts.rs
@@ -36,7 +36,7 @@ impl ClientExecutionContext for IbcContext {
             .or_insert_default()
             .map_err(|_| ClientError::ImplementationSpecific)?
             .client_state
-            .insert((), client_state.into())
+            .insert(Default::default(), client_state.into())
             .map_err(|_| ClientError::ImplementationSpecific)?;
 
         Ok(())

--- a/src/ibc/impls.rs
+++ b/src/ibc/impls.rs
@@ -123,7 +123,7 @@ impl ValidationContext for IbcContext {
                 client_id: client_id.clone(),
             })?
             .client_state
-            .get(())
+            .get(Default::default())
             .map_err(|_| ClientError::ImplementationSpecific)?
             .ok_or(ClientError::ImplementationSpecific)?
             .clone()

--- a/src/ibc/mod.rs
+++ b/src/ibc/mod.rs
@@ -222,8 +222,8 @@ pub struct Client {
     #[state(prefix(b"updates/"))]
     pub updates: Map<EpochHeight, (Timestamp, BinaryHeight)>,
 
-    #[state(prefix(b"clientState"))]
-    pub client_state: Map<(), ClientState>,
+    #[state(prefix(b""))]
+    pub client_state: Map<FixedString<"clientState">, ClientState>,
 
     #[state(prefix(b"consensusStates/"))]
     pub consensus_states: Map<EpochHeight, ConsensusState>,
@@ -900,7 +900,10 @@ mod tests {
         )
         .unwrap()
         .into();
-        client.client_state.insert((), client_state).unwrap();
+        client
+            .client_state
+            .insert(Default::default(), client_state)
+            .unwrap();
         let consensus_state = TmConsensusState::new(
             CommitmentRoot::from_bytes(&[0; 32]),
             Time::from_unix_timestamp(0, 0).unwrap(),


### PR DESCRIPTION
This PR changes the IBC client struct to use a FixedString as the map key for client states instead of an explicit state prefix.