### PR TITLE
Staking repair

### DIFF
--- a/src/coins/pool.rs
+++ b/src/coins/pool.rs
@@ -21,7 +21,7 @@ where
     contributions: Decimal,
     rewards: Map<u8, Decimal>,
     shares_issued: Decimal,
-    map: Map<K, RefCell<Entry<V>>>,
+    pub map: Map<K, RefCell<Entry<V>>>,
     rewards_this_period: Map<u8, Decimal>,
     last_period_entry: Map<u8, Decimal>,
     #[state(skip)]

--- a/src/coins/staking/mod.rs
+++ b/src/coins/staking/mod.rs
@@ -909,6 +909,24 @@ impl<S: Symbol> Staking<S> {
 
         Ok(time.seconds)
     }
+
+    pub fn repair(&mut self) -> Result<()> {
+        let mut addresses = vec![];
+        for entry in self.validators.iter()? {
+            let (address, validator) = entry?;
+            if validator.info.is_empty() {
+                addresses.push(address);
+            }
+        }
+        for address in addresses {
+            self.validators.map.remove(address)?;
+        }
+        self.unbonding_delegation_queue
+            .retain_unordered(|_| Ok(false))?;
+        self.redelegation_queue.retain_unordered(|_| Ok(false))?;
+
+        Ok(())
+    }
 }
 
 fn assert_positive(amount: Amount) -> Result<()> {


### PR DESCRIPTION
This PR adds `Staking::repair()` to clean up incorrect validator entries