### PR TITLE
Migration tweaks

### DIFF
--- a/src/coins/mod.rs
+++ b/src/coins/mod.rs
@@ -55,29 +55,14 @@ pub use ops::*;
 use bech32::{self, encode_to_fmt, FromBase32, ToBase32, Variant};
 
 use crate::collections::Next;
-use crate::migrate::Migrate;
 use ripemd::{Digest as _, Ripemd160};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
-#[orga(skip(Serialize, Deserialize, Migrate))]
+#[orga(skip(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Copy, Next)]
 pub struct Address {
     bytes: [u8; Address::LENGTH],
-}
-
-impl Migrate for Address {
-    fn migrate(
-        _src: crate::store::Store,
-        _dest: crate::store::Store,
-        bytes: &mut &[u8],
-    ) -> crate::Result<Self> {
-        let mut buf = [0u8; Address::LENGTH];
-        buf.copy_from_slice(&bytes[..Address::LENGTH]);
-        *bytes = &bytes[Address::LENGTH..];
-
-        Ok(Self { bytes: buf })
-    }
 }
 
 impl Address {

--- a/src/coins/staking/delegator.rs
+++ b/src/coins/staking/delegator.rs
@@ -10,25 +10,25 @@ use super::UNBONDING_SECONDS;
 
 #[orga]
 pub struct Unbond<S: Symbol> {
-    pub(super) coins: Share<S>,
-    pub(super) start_seconds: i64,
+    pub coins: Share<S>,
+    pub start_seconds: i64,
 }
 
 #[orga]
 #[derive(Clone)]
 pub struct Redelegation {
-    pub(super) amount: Amount,
-    pub(super) address: Address,
-    pub(super) start_seconds: i64,
+    pub amount: Amount,
+    pub address: Address,
+    pub start_seconds: i64,
 }
 
 #[orga]
 pub struct Delegator<S: Symbol> {
-    pub(super) liquid: MultiShare,
-    pub(super) staked: Share<S>,
-    pub(super) unbonding: Deque<Unbond<S>>,
-    pub(super) redelegations_out: Deque<Redelegation>,
-    pub(super) redelegations_in: Deque<Redelegation>,
+    pub liquid: MultiShare,
+    pub staked: Share<S>,
+    pub unbonding: Deque<Unbond<S>>,
+    pub redelegations_out: Deque<Redelegation>,
+    pub redelegations_in: Deque<Redelegation>,
 }
 
 impl<S: Symbol> Delegator<S> {

--- a/src/coins/staking/validator.rs
+++ b/src/coins/staking/validator.rs
@@ -155,7 +155,7 @@ impl<S: Symbol + Default> Validator<S> {
         Ok(redelegations)
     }
 
-    pub(super) fn delegator_keys(&self) -> Result<Vec<Address>> {
+    pub fn delegator_keys(&self) -> Result<Vec<Address>> {
         let mut delegator_keys: Vec<Address> = vec![];
         self.delegators
             .iter()?


### PR DESCRIPTION
This PR exposes some staking data that may be relevant during migration, and removes the non-idempotent hand implementation of `Migrate` for `Address`.