### PR TITLE
Add consensus_keys method for staking module

### DIFF
--- a/src/coins/staking/mod.rs
+++ b/src/coins/staking/mod.rs
@@ -235,6 +235,20 @@ impl<S: Symbol> Staking<S> {
         Ok(consensus_key)
     }
 
+    #[query]
+    pub fn consensus_keys(&self) -> Result<Vec<(Address, [u8; 32])>> {
+        let mut vec = vec![];
+
+        for entry in self.validators.iter()? {
+            let (_, validator) = entry?;
+            let address: Address = validator.address.into();
+            let key = self.consensus_key(address)?;
+            vec.push((address, key));
+        }
+
+        Ok(vec)
+    }
+
     pub fn address_by_consensus_key(&self, cons_key: [u8; 32]) -> Result<Option<Address>> {
         let tm_pubkey_hash = tm_pubkey_hash(cons_key)?;
         if let Some(address) = self.address_for_tm_hash.get(tm_pubkey_hash)? {


### PR DESCRIPTION
Need this later in REST server in validators and signing_infos responses, to fetch data within 2 node queries instead of 1 for validators list + 1 per validator for each consensus key.

With the use of this query, the /validators endpoint of the REST server on my public node now returns validators list with 3 seconds instead of 8 as before, so should be quite a boost.

Once this is merged, I can make another PR towards nomic-io/nomic to actually use it in REST server's endpoints.