### PR TITLE
Rust toolchain update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-05-08
+          toolchain: nightly-2024-02-14
           override: true
       - name: Cache
         uses: actions/cache@v3
@@ -49,7 +49,7 @@ jobs:
       - name: Use Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-05-08
+          toolchain: nightly-2024-02-14
           override: true
       - name: Cache
         uses: actions/cache@v3
@@ -78,7 +78,7 @@ jobs:
       - name: Use Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-05-08
+          toolchain: nightly-2024-02-14
           components: llvm-tools-preview
           override: true
       - name: Cache
@@ -119,7 +119,7 @@ jobs:
       - name: Use Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-05-08
+          toolchain: nightly-2024-02-14
           components: rustfmt
           override: true
       - name: Check
@@ -136,7 +136,7 @@ jobs:
       - name: Use Nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-05-08
+          toolchain: nightly-2024-02-14
           components: clippy
           override: true
       - name: Cache

--- a/macros/src/orga.rs
+++ b/macros/src/orga.rs
@@ -21,20 +21,30 @@ impl Default for VersionSpec {
 impl FromMeta for VersionSpec {
     fn from_expr(expr: &Expr) -> darling::Result<Self> {
         if let Expr::Range(range) = expr {
-            let (Expr::Lit(ExprLit { lit: Lit::Int(start), .. }), Expr::Lit(ExprLit { lit: Lit::Int(end), .. })) =
-                (*range
+            let (
+                Expr::Lit(ExprLit {
+                    lit: Lit::Int(start),
+                    ..
+                }),
+                Expr::Lit(ExprLit {
+                    lit: Lit::Int(end), ..
+                }),
+            ) = (
+                *range
                     .start
                     .as_ref()
                     .expect("Start of version range must be specified")
                     .clone(),
-                    *range
+                *range
                     .end
                     .as_ref()
                     .expect("End of version range must be specified")
                     .clone(),
-                )
-             else {
-                return Err(darling::Error::custom("Version must be integer or inclusive range"));
+            )
+            else {
+                return Err(darling::Error::custom(
+                    "Version must be integer or inclusive range",
+                ));
             };
 
             let start: u8 = start.base10_parse().unwrap_or_default();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-05-08"
+channel = "nightly-2024-02-14"
 

--- a/src/client/exec.rs
+++ b/src/client/exec.rs
@@ -27,6 +27,7 @@ pub enum StepResult<T: Query, U> {
 
 // TODO: dedupe sync/async versions
 
+#[allow(async_fn_in_trait)]
 pub trait Transport<T: Query + Call>: Send + Sync {
     async fn query(&self, query: T::Query) -> Result<Store>;
 

--- a/src/client/trace.rs
+++ b/src/client/trace.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 use std::cell::RefCell;
 
 thread_local! {
-    static TRACING: RefCell<bool> = RefCell::new(false);
+    static TRACING: RefCell<bool> = const { RefCell::new(false) };
 }
 
 pub fn tracing() -> bool {
@@ -43,7 +43,7 @@ pub struct Trace {
 
 impl Trace {
     pub fn bytes(&self) -> Vec<u8> {
-        vec![self.method_prefix.clone(), self.method_args.clone()].concat()
+        [self.method_prefix.clone(), self.method_args.clone()].concat()
     }
 }
 

--- a/src/coins/amount.rs
+++ b/src/coins/amount.rs
@@ -3,7 +3,7 @@ use orga::orga;
 use std::convert::TryFrom;
 
 #[orga]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct Amount {
     pub(crate) value: u64,
@@ -12,12 +12,6 @@ pub struct Amount {
 impl std::fmt::Display for Amount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.value)
-    }
-}
-
-impl Ord for Amount {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap()
     }
 }
 

--- a/src/coins/decimal.rs
+++ b/src/coins/decimal.rs
@@ -6,12 +6,12 @@ use crate::migrate::Migrate;
 use crate::orga;
 use crate::{Error, Result};
 use rust_decimal::{prelude::ToPrimitive, Decimal as NumDecimal};
-use std::cmp::Ordering;
+
 use std::convert::TryFrom;
 use std::str::FromStr;
 
 #[orga(simple, skip(Describe, Migrate))]
-#[derive(Copy, Debug)]
+#[derive(Copy, Debug, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct Decimal {
     pub(crate) value: NumDecimal,
@@ -65,12 +65,6 @@ impl From<u64> for Decimal {
 }
 
 impl Eq for Decimal {}
-
-impl Ord for Decimal {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
-    }
-}
 
 impl Decimal {
     pub fn amount(&self) -> Result<Amount> {

--- a/src/coins/mod.rs
+++ b/src/coins/mod.rs
@@ -51,7 +51,6 @@ pub use faucet::*;
 
 mod ops;
 
-
 use bech32::{self, encode_to_fmt, FromBase32, ToBase32, Variant};
 
 use crate::collections::Next;

--- a/src/coins/mod.rs
+++ b/src/coins/mod.rs
@@ -50,7 +50,7 @@ pub mod faucet;
 pub use faucet::*;
 
 mod ops;
-pub use ops::*;
+
 
 use bech32::{self, encode_to_fmt, FromBase32, ToBase32, Variant};
 

--- a/src/coins/ops/partialord.rs
+++ b/src/coins/ops/partialord.rs
@@ -1,12 +1,6 @@
 use super::super::{Amount, Decimal};
 use std::cmp::{Ordering, PartialOrd};
 
-impl PartialOrd<Amount> for Amount {
-    fn partial_cmp(&self, other: &Amount) -> Option<Ordering> {
-        self.value.partial_cmp(&other.value)
-    }
-}
-
 impl PartialOrd<Amount> for u64 {
     fn partial_cmp(&self, other: &Amount) -> Option<Ordering> {
         self.partial_cmp(&other.value)
@@ -16,12 +10,6 @@ impl PartialOrd<Amount> for u64 {
 impl PartialOrd<u64> for Amount {
     fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
         self.value.partial_cmp(other)
-    }
-}
-
-impl PartialOrd<Decimal> for Decimal {
-    fn partial_cmp(&self, other: &Decimal) -> Option<Ordering> {
-        self.value.partial_cmp(&other.value)
     }
 }
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -1075,7 +1075,7 @@ where
     /// `or_default` for a variation which will only write the newly created
     /// value if it gets modified.
     pub fn or_insert_default(self) -> Result<ChildMut<'a, K, V>> {
-        #[allow(clippy::or_fun_call)]
+        #[allow(clippy::unwrap_or_default)]
         self.or_insert(V::default())
     }
 }

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 thread_local! {
-    static COMPAT_MODE: RefCell<bool> = RefCell::new(false);
+    static COMPAT_MODE: RefCell<bool> = const { RefCell::new(false) };
 }
 
 pub fn compat_mode() -> bool {

--- a/src/ibc/impls.rs
+++ b/src/ibc/impls.rs
@@ -134,10 +134,9 @@ impl ValidationContext for IbcContext {
         if let Ok(client_state) = TmClientState::try_from(client_state.clone()) {
             Ok(client_state)
         } else {
-            Err(ClientError::UnknownClientStateType {
+            Err(ContextError::from(ClientError::UnknownClientStateType {
                 client_state_type: client_state.type_url,
-            })
-            .map_err(ContextError::from)
+            }))
         }
     }
 
@@ -565,10 +564,7 @@ impl ExecutionContext for IbcContext {
             Ok(event) => event,
             Err(_) => return,
         };
-        let mut event: tendermint_proto::v0_34::abci::Event = match event.try_into() {
-            Ok(event) => event,
-            Err(_) => return,
-        };
+        let mut event: tendermint_proto::v0_34::abci::Event = event.into();
 
         for attribute in event.attributes.iter_mut() {
             attribute.index = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bound_map)]
 #![feature(associated_type_defaults)]
 #![feature(trivial_bounds)]
 #![allow(incomplete_features)]
@@ -8,11 +7,9 @@
 #![feature(adt_const_params)]
 #![feature(fn_traits)]
 #![feature(async_closure)]
-#![feature(local_key_cell_methods)]
 #![feature(auto_traits)]
 #![feature(negative_impls)]
 #![feature(lazy_cell)]
-#![feature(async_fn_in_trait)]
 #![feature(trait_upcasting)]
 
 extern crate self as orga;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -256,9 +256,9 @@ mod tests {
             }
 
             Ok(Self {
-                bar: u32::decode(&mut bytes)?.try_into().unwrap(),
+                bar: u32::decode(&mut bytes)?.into(),
                 boop: 43,
-                baz: Map::migrate(src.sub(&[1]), dest.sub(&[1]), &mut bytes)?,
+                baz: Map::migrate(src.sub(&[1]), dest.sub(&[1]), bytes)?,
                 beep: Map::migrate(src.sub(&[2]), dest.sub(&[3]), bytes)?,
             })
         }


### PR DESCRIPTION
This PR updates the toolchain file to `nightly-2024-02-14` and fixes warnings from newly-introduced clippy lints.