### PR TITLE
`Map` reverse iteration fix

### DIFF
--- a/src/collections/deque.rs
+++ b/src/collections/deque.rs
@@ -491,6 +491,53 @@ mod test {
     }
 
     #[test]
+    fn deque_iter_rev() -> crate::Result<()> {
+        let mut store = Store::with_map_store().sub(&[123]);
+        let mut deque: Deque<u32> = Deque::new();
+        deque.attach(store.clone())?;
+
+        deque.push_back(1)?;
+        deque.push_back(2)?;
+        deque.push_back(3)?;
+
+        let mut bytes = vec![];
+
+        use crate::store::Write;
+        deque.flush(&mut bytes)?;
+        store.put(vec![], bytes.clone()).unwrap();
+
+        let mut deque: Deque<u32> = Deque::load(store.clone(), &mut &bytes[..])?;
+        deque.attach(store)?;
+
+        let mut iter = deque.iter()?.rev();
+        assert_eq!(*iter.next().unwrap()?, 3);
+        assert_eq!(*iter.next().unwrap()?, 2);
+        assert_eq!(*iter.next().unwrap()?, 1);
+        assert!(iter.next().is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn deque_iter_rev_noflush() -> crate::Result<()> {
+        let store = Store::with_map_store().sub(&[123]);
+        let mut deque: Deque<u32> = Deque::new();
+        deque.attach(store.clone())?;
+
+        deque.push_back(1)?;
+        deque.push_back(2)?;
+        deque.push_back(3)?;
+
+        let mut iter = deque.iter()?.rev();
+        assert_eq!(*iter.next().unwrap()?, 3);
+        assert_eq!(*iter.next().unwrap()?, 2);
+        assert_eq!(*iter.next().unwrap()?, 1);
+        assert!(iter.next().is_none());
+
+        Ok(())
+    }
+
+    #[test]
     fn deque_swap() {
         let mut deque: Deque<u32> = Deque::new();
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -756,6 +756,11 @@ impl<'a, S: Default + Read, K: Decode> StoreNextIter<'a, S, K> {
         match &self.next_key {
             Bound::Excluded(end) if key <= *end => return None,
             Bound::Included(end) if key < *end => return None,
+            // FIXME: this is the one place where iterator ranges become
+            // un-pure, due to the fact that we store the base value of
+            // collections at the empty key, which overlaps with the descendant
+            // keyspace.
+            Bound::Unbounded if key.is_empty() => return None,
             _ => {}
         };
 

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -1759,9 +1759,31 @@ mod tests {
         let map: Map<u32, Map<u32, u32>> = Map::with_store(store).unwrap();
 
         let mut iter = map.iter().unwrap().rev();
-        assert_eq!(*iter.next().unwrap().unwrap().0, 3);
-        assert_eq!(*iter.next().unwrap().unwrap().0, 2);
-        assert_eq!(*iter.next().unwrap().unwrap().0, 1);
+
+        let (key, submap) = iter.next().unwrap().unwrap();
+        assert_eq!(*key, 3);
+        let mut subiter = submap.iter().unwrap().rev().peekable();
+        assert_eq!(*subiter.peek().unwrap().as_ref().unwrap().0, 5);
+        assert_eq!(*subiter.next().unwrap().unwrap().1, 50);
+        assert_eq!(*subiter.peek().unwrap().as_ref().unwrap().0, 4);
+        assert_eq!(*subiter.next().unwrap().unwrap().1, 40);
+        assert!(subiter.next().is_none());
+
+        let (key, submap) = iter.next().unwrap().unwrap();
+        assert_eq!(*key, 2);
+        assert!(submap.iter().unwrap().next().is_none());
+
+        let (key, submap) = iter.next().unwrap().unwrap();
+        assert_eq!(*key, 1);
+        let mut subiter = submap.iter().unwrap().rev().peekable();
+        assert_eq!(*subiter.peek().unwrap().as_ref().unwrap().0, 3);
+        assert_eq!(*subiter.next().unwrap().unwrap().1, 30);
+        assert_eq!(*subiter.peek().unwrap().as_ref().unwrap().0, 2);
+        assert_eq!(*subiter.next().unwrap().unwrap().1, 20);
+        assert_eq!(*subiter.peek().unwrap().as_ref().unwrap().0, 1);
+        assert_eq!(*subiter.next().unwrap().unwrap().1, 10);
+        assert!(subiter.next().is_none());
+
         assert!(iter.next().is_none());
     }
 


### PR DESCRIPTION
This PR fixes an issue in the `Map` iterator implementation.

`Map` creates a base entry for each child at the empty key of the child's keyspace to store the child's encoding bytes. This makes the contract between the `Map` and child slightly impure, causing the base entry to be included when iterating over all of the keyspace. This was properly skipped for forward iteration, but was included for reverse iteration which can cause various symptoms depending on the state of the backing store.

In the future, we'll want to clean up the contract between `Map` and child in order to cleanly allow children to manage all of their keyspace. However, after this fix the only known issue will be that iteration will not yield the value for `Map`s using zero-sized keys (e.g. `Map<(), _>`), which is relatively harmless.