### PR TITLE
Temporary fix for client tracing for iterators

### DIFF
--- a/src/client/exec.rs
+++ b/src/client/exec.rs
@@ -143,7 +143,11 @@ where
             (key.clone(), StepResult::FetchKey(key))
         }
         Err(Error::StoreErr(store::Error::GetNextUnknown(key))) => {
-            (key.clone(), StepResult::FetchNext(key))
+            // (key.clone(), StepResult::FetchNext(key))
+            // TODO: optimistically attempt to trace and only use fetchnext as fallback. we
+            // only do this because unwrapping a collections::Map::Iter entry
+            // does not push a trace yet
+            return Ok(StepResult::FetchNext(key));
         }
         Err(Error::StoreErr(store::Error::GetPrevUnknown(maybe_key))) => {
             if let Some(key) = maybe_key {

--- a/src/client/exec.rs
+++ b/src/client/exec.rs
@@ -440,7 +440,8 @@ mod tests {
         assert_eq!(res, 3);
         assert_eq!(
             client.queries.into_inner().unwrap(),
-            vec![vec![2], vec![0, 128]]
+            // TODO: 2nd query shouldn't be necessary
+            vec![vec![2], vec![3, 0, 1], vec![0, 128]]
         );
     }
 


### PR DESCRIPTION
This PR fixes client function query resolution getting stuck when iterating over `Map` iterators.

This fix should eventually be replaced to reduce the number of requests made for client queries.